### PR TITLE
feat: add /wp-yolo full-site demo-to-theme builder (+ /wp-cpt, search page type)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+### Added
+- **`/wp-yolo` command**: converts a complete multi-page HTML demo folder into a WordPress theme in one pass — normalizes the demo, infers pages/sections/fields/content-types, and drives the existing build pipeline. Flag-controlled autonomy (`--yolo`, `--careful`).
+- **`/wp-cpt` command**: custom post type builder — registers a CPT and generates its fields, archive, single, optional teaser query-section, and seed helper.
+- **`wp-normalize` agent**: analyzes an arbitrary demo folder into the plugin's canonical delimited format plus a build manifest, splitting sections and classifying static-repeater vs custom-post-type groups.
+- **`search` page type for `/wp-page`**: generates a design-matched `search.php`. `/wp-yolo` always builds `404` and `search`.
+
 ## [1.5.0] - 2026-07-08
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -132,11 +132,19 @@ Each reads the demo, dispatches specialized agents (`wp-template`, `wp-css`, `wp
 
 ### 4. Build sections
 
+Build sections one at a time:
+
 ```
 /wp-section hero
 /wp-section services
 /wp-section values
 /wp-section contact
+```
+
+**Or, build the entire site from an existing HTML demo in one pass:**
+
+```
+/wp-yolo /path/to/demo-folder
 ```
 
 Each command generates three files in parallel:
@@ -226,7 +234,9 @@ Clones a remote/staging WordPress site to local dev. Supports SSH automated mode
 | `/wp-header` | Build header with nav, logo, language switcher |
 | `/wp-footer` | Build footer from settings page fields |
 | `/wp-section <name>` | One-shot section: ACF fields + template + CSS |
-| `/wp-page <type>` | Page template generator (blog, legal, 404, generic, custom) |
+| `/wp-page <type>` | Page template generator (blog, legal, 404, generic, custom, search) |
+| `/wp-cpt <name>` | Custom post type builder — generates fields, archive, single, seed helper |
+| `/wp-yolo <demo-folder>` | Convert complete demo folder to WordPress theme in one pass |
 | `/wp-settings` | Extend the settings page with new fields |
 | `/wp-responsive-check` | Responsive validation at 5 viewports |
 | `/wp-finalize` | Pre-delivery validation checklist |

--- a/agents/wp-normalize.md
+++ b/agents/wp-normalize.md
@@ -1,0 +1,206 @@
+---
+name: wp-normalize
+description: Demo-folder analyzer — converts an arbitrary multi-page HTML site into the plugin's canonical delimited demo format plus a build manifest, splitting sections and classifying content types
+tools: Read, Write, Edit, Grep, Glob
+---
+
+# WordPress Demo Normalizer
+
+You convert a complete, externally-authored multi-page HTML demo into artifacts the
+claude-wp-builder pipeline consumes: canonical delimited `demo/*.html` files and a
+`demo/.yolo-manifest.json`. You reason over the DOM — there is no parser shipped with
+this agent, this is an LLM-reasoning task. The checkpoint that follows Phase 1 is the
+safety net for that non-determinism, so you MUST record confidence and rationale for
+every non-obvious decision.
+
+## Analysis Procedure
+
+Work through these steps, in order, for the demo folder you are given:
+
+1. **Scan** the folder → all `.html` (pages), CSS, JS, images. Each HTML file becomes a
+   page; the slug comes from the filename; `index.html` maps to the home page /
+   `front-page.php`.
+2. **Parse each page's DOM** → identify:
+   - **Header** (detect whether it is shared across pages → build once if so).
+   - **Footer** (shared → build once).
+   - **Body sections** — split by explicit `<section>` elements first; else fall back to
+     heuristic segmentation (major headings / block boundaries / background changes).
+     Name each section from its `id`/`class`/heading text.
+3. **Resolve CSS** — match external stylesheet rules to each section (by selector) so
+   each section carries its own styles for the `wp-css` agent; extract global design
+   tokens (colors / fonts / spacing).
+4. **Extract content** — per-section text (headings, paragraphs, CTAs, repeating
+   cards/list items) drives ACF field inference + seed values; catalog images per
+   section.
+5. **Classify content-types** (see Classifier Rubric below) — every repeating card group
+   becomes `static-repeater` vs `custom-post-type`, with confidence + rationale.
+6. **Emit artifacts:**
+   - `demo/<slug>.html` per page **with `<!-- SECTION: X -->` delimiters + consolidated
+     CSS** — the exact canonical format the existing builders consume (so `/wp-section`,
+     `/wp-header`, etc. still work for later fixups). Consolidate every matched external
+     CSS rule for a section inline, into that emitted page, so each page is self-contained.
+   - `demo/.yolo-manifest.json` — orchestration source of truth: pages → sections →
+     field-guesses → assets → shared-flags → contentTypes + links. Also the checkpoint
+     report.
+
+### Canonical section delimiter format
+
+Use this exact delimiter pair around every section you split out, matching
+`commands/wp-section.md` and `commands/wp-demo.md`:
+
+```html
+<!-- ============ SECTION: <Name> ============ -->
+...section markup...
+<!-- ============ END SECTION: <Name> ============ -->
+```
+
+## Classifier Rubric (CPT vs. static repeater)
+
+For every repeating card group found on a page, decide `static-repeater` vs
+`custom-post-type` using these signals.
+
+**Signals → CPT** (any one strong signal, or several weak signals together):
+
+1. A **"Show more / View all / See all"** link leaving the section to another page
+   (matches View all|Show more|See all; kind static-repeater|repeater).
+2. Cards **link to individual detail pages** (`team/john.html`, `member-*.html`).
+3. A **dedicated listing page exists** in the demo (a full grid of the same card type).
+4. **Collection-noun naming**: team, staff, services, projects, portfolio, products,
+   testimonials, news, events, properties, menu, etc.
+5. **Many uniform cards with rich per-item data** (photo + name + role + bio), not 2–3
+   structural blocks.
+6. **Same card type appears on 2+ pages** (e.g. a home teaser + a full listing page).
+
+**Signals → static repeater:** small fixed count, no outbound links, no detail pages,
+structural content (features, steps, stats, pricing, FAQ).
+
+For every repeating group, emit in the manifest:
+
+```jsonc
+{ "kind": "static-repeater" | "custom-post-type", "cpt": "team", "confidence": 0.9,
+  "rationale": "‘View all team’ link → team.html; cards link to team/*.html" }
+```
+
+Always include `confidence` (0–1) and `rationale` (one sentence, cite the concrete signal
+observed) for every classification that isn't a slam-dunk match on a single unambiguous
+signal — the checkpoint reader relies on this text.
+
+## Cross-page linkage rules
+
+- A demo page like `team.html` → recognized as the **archive** of CPT `team`
+  (`archive-team.php`), **not** a `page-team.php` static page. This page gets
+  `role: 'cpt-archive'` in the manifest and **no WP Page is created** for it (the archive
+  has its own URL via `has_archive`, wired in Phase 2/3, not by `/wp-seed` page creation).
+- Detail pages like `team/john.html` → **seed data** for single posts, not templates —
+  each becomes one entry in that content type's `seed[]`, not a page.
+- The home "Team" block (the teaser) → a **query section**, i.e. `kind: 'cpt-teaser'` in
+  the manifest, not a repeater — it runs a `WP_Query` against the CPT rather than holding
+  its own repeater fields.
+
+## `.yolo-manifest.json` Schema
+
+Emit exactly this key set (Task 4's orchestrator consumes these keys verbatim):
+
+```jsonc
+{
+  "source": "<demo-folder-path>",
+  "pages": [
+    {
+      "slug": "<string>",
+      "role": "home" | "inner" | "cpt-archive" | "blog",
+      "file": "demo/<slug>.html",
+      "sections": [
+        {
+          "name": "<string>",
+          "kind": "static" | "contact" | "cpt-teaser",
+          "cpt": "<string, optional — set when kind is cpt-teaser>",
+          "confidence": 0.0,
+          "rationale": "<string, optional — required for any non-obvious call>",
+          "fields": [ /* ACF field guesses */ ],
+          "assets": [ /* image paths referenced by this section */ ]
+        }
+      ],
+      "cpt": "<string, optional — set on cpt-archive pages>"
+    }
+  ],
+  "shared": {
+    "header": true,
+    "footer": true,
+    "headerDivergentPages": [ /* slugs whose header differs from home's */ ],
+    "footerDivergentPages": [ /* slugs whose footer differs from home's */ ]
+  },
+  "contentTypes": [
+    {
+      "name": "<string>",
+      "fields": [ /* photo, name, role, bio, ... */ ],
+      "hasTeaser": true,
+      "seed": [ /* one entry per demo card / detail page */ ]
+    }
+  ],
+  "review": [ /* every low-confidence decision, one string each, human-readable */ ]
+}
+```
+
+### Filled example
+
+A home page with a hero and a team teaser, a `team` CPT with a dedicated archive page,
+and seed entries harvested from detail pages:
+
+```jsonc
+{
+  "source": "demo-source/agency-co",
+  "pages": [
+    {
+      "slug": "index", "role": "home", "file": "demo/index.html",
+      "sections": [
+        { "name": "hero", "kind": "static", "fields": [
+            { "name": "hero_title", "type": "text" },
+            { "name": "hero_subtitle", "type": "textarea" },
+            { "name": "hero_image", "type": "image" }
+          ], "assets": [ "images/hero-bg.jpg" ] },
+        { "name": "team", "kind": "cpt-teaser", "cpt": "team", "confidence": 0.9,
+          "rationale": "'View all team' link → team.html; cards link to team/john.html, team/jane.html",
+          "fields": [
+            { "name": "team_heading", "type": "text" },
+            { "name": "team_intro", "type": "textarea" }
+          ], "assets": [] }
+      ]
+    },
+    {
+      "slug": "team", "role": "cpt-archive", "file": "demo/team.html", "cpt": "team",
+      "sections": []
+    }
+  ],
+  "shared": {
+    "header": true, "footer": true,
+    "headerDivergentPages": [], "footerDivergentPages": [ "team" ]
+  },
+  "contentTypes": [
+    {
+      "name": "team",
+      "fields": [
+        { "name": "photo", "type": "image" },
+        { "name": "name", "type": "text" },
+        { "name": "role", "type": "text" },
+        { "name": "bio", "type": "textarea" }
+      ],
+      "hasTeaser": true,
+      "seed": [
+        { "name": "John Smith", "role": "Founder", "photo": "team/john.jpg",
+          "bio": "...", "source": "team/john.html" },
+        { "name": "Jane Doe", "role": "Lead Designer", "photo": "team/jane.jpg",
+          "bio": "...", "source": "team/jane.html" }
+      ]
+    }
+  ],
+  "review": [
+    "team teaser classified cpt-teaser at confidence 0.9 — verify 'View all' link target",
+    "footer on team.html differs from home footer (missing newsletter form) — built from home's footer, flag for manual check"
+  ]
+}
+```
+
+List **every** low-confidence decision (any classification you are not fully certain of,
+any inferred field, any structural guess made from heuristic segmentation rather than
+explicit `<section>` tags) as a plain-language entry in `review[]`. This list is read
+verbatim at the Phase 1 checkpoint.

--- a/agents/wp-normalize.md
+++ b/agents/wp-normalize.md
@@ -89,6 +89,11 @@ classified **static-repeater** → that section's `kind: "static"`; a group clas
 custom-post-type → the teaser block's section `kind: "cpt-teaser"`, plus a
 `contentTypes[]` entry and (if a dedicated listing page exists) a `cpt-archive` page.
 
+**Contact detection** (mirrors `commands/wp-section.md` Step 3.5): a section is
+`kind: "contact"` when it contains a `<form>` with both `<input type="email">` and a
+`<textarea>`, OR its name matches `contact` / `contact-us` / `contacto` / `get-in-touch`
+(case-insensitive). This takes precedence over static/cpt classification for that section.
+
 ## Cross-page linkage rules
 
 - A demo page like `team.html` → recognized as the **archive** of CPT `team`

--- a/agents/wp-normalize.md
+++ b/agents/wp-normalize.md
@@ -62,7 +62,6 @@ For every repeating card group found on a page, decide `static-repeater` vs
 **Signals → CPT** (any one strong signal, or several weak signals together):
 
 1. A **"Show more / View all / See all"** link leaving the section to another page
-   (matches View all|Show more|See all; kind static-repeater|repeater).
 2. Cards **link to individual detail pages** (`team/john.html`, `member-*.html`).
 3. A **dedicated listing page exists** in the demo (a full grid of the same card type).
 4. **Collection-noun naming**: team, staff, services, projects, portfolio, products,
@@ -84,6 +83,11 @@ For every repeating group, emit in the manifest:
 Always include `confidence` (0–1) and `rationale` (one sentence, cite the concrete signal
 observed) for every classification that isn't a slam-dunk match on a single unambiguous
 signal — the checkpoint reader relies on this text.
+
+When emitting the manifest, map the verdict to the `sections[].kind` enum: a group
+classified **static-repeater** → that section's `kind: "static"`; a group classified
+custom-post-type → the teaser block's section `kind: "cpt-teaser"`, plus a
+`contentTypes[]` entry and (if a dedicated listing page exists) a `cpt-archive` page.
 
 ## Cross-page linkage rules
 

--- a/commands/wp-cpt.md
+++ b/commands/wp-cpt.md
@@ -1,0 +1,81 @@
+---
+description: Custom post type builder — registers a CPT and generates its fields, archive, single, optional teaser query-section, and seed helper
+allowed-tools: Read, Write, Edit, Bash, Grep, Glob, Agent
+argument-hint: "<name> [--no-teaser] [--from-demo <section-name>]"
+---
+
+# WP CPT — Custom Post Type Builder
+
+Register a custom post type and generate everything it needs: registration, ACF fields bound to the type, archive + single templates, an optional home/teaser query-section, and a seed helper.
+
+## Step 1: Parse Arguments
+- **First word** = CPT name, singular lowercase (e.g., `team`, `service`, `project`). Required.
+- `--no-teaser` = skip the teaser query-section.
+- `--from-demo <section-name>` = read field/seed hints from that section in `demo/index.html`.
+
+If no name: print usage error and exit.
+
+## Step 2: Read Project Context
+Read `.claude/CLAUDE.md` for function prefix, theme slug, languages, theme directory. If missing, tell the user to run `/wp-init` first and exit.
+
+## Step 3: Register the CPT and generate fields (parallel)
+
+Dispatch **wp-template** agent:
+
+> Generate `inc/post-types/<name>.php`:
+> - `register_post_type( '<name>', [...] )` hooked on `init` via `add_action`
+> - Labels for singular/plural (primary language from CLAUDE.md)
+> - `'public' => true`, `'has_archive' => true`, `'menu_icon'` (choose a dashicon fitting the noun),
+>   `'supports' => ['title','editor','thumbnail']`, `'rewrite' => ['slug' => '<name>']`
+> - Escaping on labels; text domain = theme slug
+> Then ensure `functions.php` `require`s every file in `inc/post-types/` (add a glob-require loop if not present).
+
+Dispatch **wp-acf** agent:
+
+> Generate `fields/<name>.php`:
+> - Field group bound with location rule `post_type == <name>`
+> - Fields inferred from the demo card (or `--from-demo` section): image (photo/thumbnail),
+>   text (name/title — usually the post title, skip if so), text (role/subtitle), textarea/wysiwyg (bio/description),
+>   repeater (socials: platform + url) when present
+> - Bilingual variants per `wp-bilingual` when languages has a secondary
+> - Group key: `group_<name>`
+
+## Step 4: Archive and single templates
+
+Dispatch **wp-template** agent:
+
+> Generate `archive-<name>.php`:
+> - `get_header()`, archive intro/title, grid loop over the main query rendering each item as a card
+>   (reuse `template-parts/<name>/card.php`), `the_posts_pagination()`, `get_footer()`
+> Generate `single-<name>.php`:
+> - `get_header()`, item detail rendered from the CPT ACF fields via `prefix_get_field()`,
+>   `get_footer()`, BEM classes `.<name>-single__*`
+> Generate `template-parts/<name>/card.php`:
+> - Single card markup shared by archive + teaser: thumbnail, title (`get_the_title()`),
+>   role, excerpt/bio; permalink via `get_permalink()`
+
+Dispatch **wp-css** agent:
+
+> Add `.<name>-archive`, `.<name>-card`, `.<name>-single` CSS within delimiters using design tokens.
+
+## Step 5: Teaser query-section (unless --no-teaser)
+
+Dispatch **wp-template** + **wp-acf** + **wp-css** (mirror the /wp-section flow):
+
+> `template-parts/section-<name>.php`:
+> - `WP_Query( ['post_type' => '<name>', 'posts_per_page' => N, 'orderby' => 'menu_order'] )`
+> - Section chrome from ACF: `prefix_get_field('<name>_heading')`, intro, button label
+> - Render N cards via `template-parts/<name>/card.php`
+> - "Show more" button → `get_post_type_archive_link('<name>')`
+> `fields/section-<name>.php`: chrome-only ACF group (heading, intro, button_label) — NOT the items
+> Inject `get_template_part('template-parts/section', '<name>')` into `front-page.php` at the sections placeholder.
+
+## Step 6: Seed helper
+
+Append to the theme's seed routine (or emit `inc/seed/<name>.php`) WP-CLI calls to create N `<name>` posts
+from the demo cards / detail pages: `wp post create --post_type=<name> --post_title='...' --porcelain`,
+then set ACF fields and sideload the card image into the media library and set the thumbnail.
+Primary language only; flag secondary.
+
+## Step 7: Print Summary
+List every file created and the registered post type, archive URL, and seed count.

--- a/commands/wp-cpt.md
+++ b/commands/wp-cpt.md
@@ -72,9 +72,13 @@ Dispatch **wp-template** + **wp-acf** + **wp-css** (mirror the /wp-section flow)
 
 ## Step 6: Seed helper
 
-Append to the theme's seed routine (or emit `inc/seed/<name>.php`) WP-CLI calls to create N `<name>` posts
-from the demo cards / detail pages: `wp post create --post_type=<name> --post_title='...' --porcelain`,
-then set ACF fields and sideload the card image into the media library and set the thumbnail.
+**Always emit `inc/seed/<name>.php`** — a single runnable seeder that creates the N `<name>`
+posts from the demo cards / detail pages. It must be executable standalone via the project's
+WP-CLI wrapper (`$WP eval-file inc/seed/<name>.php`) so a later `/wp-yolo` Phase 3 (or a
+manual run) can create the posts deterministically. For each post: create it
+(`wp_insert_post` with `post_type => '<name>'`), set its ACF fields, and sideload the card
+image (`media_sideload_image`) into the media library and set it as the thumbnail.
+Make it idempotent where practical (skip if a post with the same title already exists).
 Primary language only; flag secondary.
 
 ## Step 7: Print Summary

--- a/commands/wp-init.md
+++ b/commands/wp-init.md
@@ -266,6 +266,7 @@ Create `.claude/CLAUDE.md` at the **project root** (the directory containing `wp
 2. `/wp-header` — Build header.php from the demo
 3. `/wp-footer` — Build footer.php from the demo
 4. `/wp-section <name>` — Build each section (ACF fields + template + CSS)
+Or: `/wp-yolo <demo-folder>` — build the whole site from an existing HTML demo in one pass.
 5. `/wp-page <type>` — Generate page templates (blog, generic, legal, 404)
 6. `/wp-settings` — Extend the settings/options page
 7. `/wp-responsive-check <url>` — Validate responsive design

--- a/commands/wp-page.md
+++ b/commands/wp-page.md
@@ -1,5 +1,5 @@
 ---
-description: Generate page templates — blog, generic, legal, 404, or custom page types
+description: Generate page templates — blog, generic, legal, 404, search, or custom page types
 allowed-tools: Read, Write, Edit, Bash, Grep, Glob, Agent
 argument-hint: "<type> [name] [screenshot-path]"
 ---
@@ -11,7 +11,7 @@ Generate complete page templates with associated ACF fields and CSS based on the
 ## Step 1: Parse Arguments
 
 Parse `$ARGUMENTS`:
-- **First word** = page type (required): `blog`, `generic`, `legal`, `404`, or `custom`
+- **First word** = page type (required): `blog`, `generic`, `legal`, `404`, `search`, or `custom`
 - **Second word** = name (required only for `custom` type)
 - **Remaining words** = screenshot path (optional)
 
@@ -19,12 +19,13 @@ If no type is provided, print an error:
 ```
 Error: Page type is required.
 Usage: /wp-page <type> [name] [screenshot-path]
-Types: blog, generic, legal, 404, custom
+Types: blog, generic, legal, 404, search, custom
 Examples:
   /wp-page blog
   /wp-page generic
   /wp-page legal
   /wp-page 404
+  /wp-page search
   /wp-page custom pricing
 ```
 
@@ -171,6 +172,27 @@ Dispatch **wp-template** agent:
 Dispatch **wp-css** agent:
 
 > Add 404 page CSS to `assets/css/styles.css` within delimiters. Include: centered layout, large 404 text, search form styling, responsive design.
+
+---
+
+### Type: search
+
+Dispatch **wp-template** agent:
+
+> Generate `search.php`:
+> - `get_header()`
+> - Page title: `printf( esc_html__( 'Search results for: %s', '<slug>' ), '<span>' . get_search_query() . '</span>' )`
+> - `if ( have_posts() )` loop reusing the site's card/list markup via
+>   `get_template_part('template-parts/content', get_post_type())` with a fallback template part
+> - `the_posts_pagination()`
+> - `else` → styled **no-results** block: heading, message, and `get_search_form()`
+> - `get_footer()`
+> - BEM classes: `.search-results__*`, matching the design tokens in the theme CSS
+
+Dispatch **wp-css** agent:
+
+> Add search-results + no-results state CSS to the theme stylesheet within delimiters,
+> using the project's design-system custom properties (no new colors).
 
 ---
 

--- a/commands/wp-section.md
+++ b/commands/wp-section.md
@@ -1,7 +1,7 @@
 ---
 description: One-shot section builder — generates ACF fields + template part + CSS for a section from the demo
 allowed-tools: Read, Write, Edit, Bash, Grep, Glob, Agent
-argument-hint: "<section-name> [screenshot-path] [--cf7]"
+argument-hint: "<section-name> [screenshot-path] [--cf7] [--page <slug>] [--target <template>]"
 ---
 
 # WP Section — One-Shot Section Builder
@@ -12,16 +12,19 @@ Generate ACF field definitions, a template part, and CSS for a single section �
 
 Parse `$ARGUMENTS`:
 - **First word** = section name (required, e.g., `hero`, `services`, `about`, `contact`)
-- **Remaining words** = screenshot path (optional)
+- **Remaining non-flag word** = screenshot path (optional; a flag token or its value is never treated as the screenshot path)
 - **`--cf7` flag** = force CF7 contact form integration (optional)
+- **`--page <slug>`** = read the section from `demo/<slug>.html` instead of `demo/index.html` (optional, **default `index`** — existing behavior unchanged when omitted)
+- **`--target <template>`** = inject the `get_template_part` call into `<template>` (e.g. `page-about.php`) instead of `front-page.php` (optional, **default `front-page.php`** — existing behavior unchanged when omitted)
 
 If no section name is provided, print an error:
 ```
 Error: Section name is required.
-Usage: /wp-section <section-name> [screenshot-path] [--cf7]
+Usage: /wp-section <section-name> [screenshot-path] [--cf7] [--page <slug>] [--target <template>]
 Example: /wp-section hero
          /wp-section services /path/to/screenshot.png
          /wp-section contact --cf7
+         /wp-section about-story --page about --target page-about.php
 ```
 
 ## Step 2: Read Project Context
@@ -34,7 +37,9 @@ Read `.claude/CLAUDE.md` to extract:
 
 ## Step 3: Read Demo Section
 
-Read `demo/index.html` and extract the section matching:
+Read the demo page for this section — `demo/<slug>.html` where `<slug>` is the `--page`
+value (**default `index`**, i.e. `demo/index.html` when `--page` is omitted) — and extract
+the section matching:
 ```
 <!-- ============ SECTION: <Name> ============ -->
 ...
@@ -61,7 +66,7 @@ If any condition is true, set `is_contact_section = true`. This changes the disp
 
 ## Step 4: Determine Target Page Template
 
-The section will be included in a page template. Default is `front-page.php`. If the user specifies a different target, use that instead.
+The section will be included in a page template. Default is `front-page.php`. If `--target <template>` is provided, inject into that template instead (e.g. `page-about.php`). Everywhere below that names `front-page.php` refers to this resolved target template.
 
 ## Step 5: Dispatch Agents
 
@@ -228,7 +233,7 @@ Wait for all Phase 1 agents to complete. Extract form IDs from wp-cf7 output.
 
 ## Step 6: Add to Page Template
 
-After all agents complete, check if the target page template (e.g., `front-page.php`) already includes this section:
+After all agents complete, check if the resolved target page template (the `--target` value, default `front-page.php`) already includes this section:
 
 ```php
 get_template_part('template-parts/section', '<name>');

--- a/commands/wp-seed.md
+++ b/commands/wp-seed.md
@@ -1,7 +1,7 @@
 ---
 description: Seed WordPress content from demo HTML — parses sections, creates pages, imports media, populates ACF fields, builds menus, supports bilingual content
 allowed-tools: Read, Write, Edit, Bash, Grep, Glob
-argument-hint: "[demo-file.html]"
+argument-hint: "[demo-file.html] [--exclude-slugs <slug,slug,...>]"
 ---
 
 # WP Seed — Content Seeding from Demo HTML
@@ -38,9 +38,17 @@ If this fails, abort with a message suggesting the user check that the WordPress
 
 ## Phase 1: Parse Demo HTML
 
+### Parse arguments
+
+- **First non-flag word** = demo file path (optional). If provided and it points to a file, use that file.
+- **`--exclude-slugs <slug,slug,...>`** = optional comma-separated list of page slugs to
+  **skip** when creating WP Pages in Phase 2 (default: none — existing behavior unchanged).
+  Use this to avoid creating a WP Page for a slug that is served by a CPT archive
+  (`archive-<slug>.php` / `has_archive`), which would otherwise collide.
+
 ### Locate the demo file
 
-- If `$ARGUMENTS` is provided and points to a file, use that file.
+- If a demo file path was provided in `$ARGUMENTS`, use that file.
 - Otherwise, check for `demo/index.html` in the current working directory.
 - If no demo file is found, abort with:
   > "No demo file found. Provide a path as argument or ensure `demo/index.html` exists."
@@ -115,7 +123,7 @@ Languages:      en (primary), es (additional)
 
 ## Phase 2: Create Pages
 
-Create a WordPress page for each page found in the navigation (or each HTML file in multi-page demos).
+Create a WordPress page for each page found in the navigation (or each HTML file in multi-page demos). **Skip any slug listed in `--exclude-slugs`** — do not create a WP Page for it (its URL is provided by a CPT archive via `has_archive`, and a WP Page would collide with `archive-<slug>.php`).
 
 ```bash
 # Create each page and capture its ID

--- a/commands/wp-yolo.md
+++ b/commands/wp-yolo.md
@@ -1,0 +1,129 @@
+---
+description: Full-site builder — convert a complete multi-page HTML demo folder into a WordPress theme in one pass
+allowed-tools: Read, Write, Edit, Bash, Grep, Glob, Agent
+argument-hint: "<demo-folder> [--yolo] [--careful]"
+---
+
+# WP YOLO — Full-Site Demo → WordPress Theme
+
+Convert a complete multi-page HTML demo into a working theme in one orchestrated pass,
+reusing the plugin's existing build pipeline end to end. Run this AFTER `/wp-create` +
+`/wp-init` have scaffolded the project. This command does not reimplement any builder —
+it dispatches the `wp-normalize` agent once, then drives the existing commands/agents in
+dependency order.
+
+## Step 1: Parse Arguments & Gate
+
+Parse `$ARGUMENTS`:
+- **First non-flag word** = path to the demo folder (required). Error and exit if missing,
+  or if the path is not a directory:
+  ```
+  Error: A demo folder is required.
+  Usage: /wp-yolo <path-to-demo-folder> [--yolo] [--careful]
+  ```
+- **`--yolo`** = no checkpoint at all (ingest → build → seed → finalize → report, hands-off).
+- **`--careful`** = checkpoint after normalization AND a per-page confirm before each inner
+  page's build in Phase 2.
+- **default** (neither flag) = a single checkpoint after normalization, then hands-off.
+
+Read `.claude/CLAUDE.md` at the project root. If it does not exist, refuse:
+```
+Error: No .claude/CLAUDE.md found. Run /wp-init first to scaffold the project.
+```
+Extract function prefix, theme slug, languages (primary + secondary), template
+(basic|tailwind), and CF plugin (scf|acf) — needed by every downstream command.
+
+## Step 2: Phase 1 — Normalize
+
+Dispatch the **wp-normalize** agent against the demo folder from Step 1. It scans every
+page, resolves shared header/footer, splits sections, classifies content types
+(static-repeater vs custom-post-type), and writes:
+- `demo/*.html` — canonical, delimited pages (the same `<!-- SECTION: X -->` format the
+  existing builders consume)
+- `demo/.yolo-manifest.json` — the orchestration source of truth (`pages[]`, `shared`,
+  `contentTypes[]`, `review[]`)
+
+Read `demo/.yolo-manifest.json` back once the agent completes.
+
+## Step 3: Checkpoint (skipped under --yolo)
+
+Unless `--yolo` is set, print the detected map from the manifest:
+- Pages (slug, role: home / inner / cpt-archive / blog) and their sections (name, kind,
+  confidence where < 1.0)
+- Shared header/footer flags and any divergent pages
+- Content-type classifications (`contentTypes[]`) with field lists
+- The full `review[]` list of low-confidence decisions
+
+Ask the user to **approve / edit / abort**:
+- Edit = rename/merge/split a section, drop a page, flip a `kind` between `static` and
+  `cpt-teaser`, etc. Apply edits directly to `demo/.yolo-manifest.json` before continuing.
+- Abort = stop here, leave `demo/*.html` and the manifest in place for a later resumed run.
+
+Under `--yolo`, skip this step and proceed straight to Phase 2 with the manifest as
+emitted by `wp-normalize`.
+
+## Step 4: Phase 2 — Build (dependency order)
+
+Drive the existing commands/agents in this exact order, reading everything from the
+(possibly edited) manifest. Do not reimplement any builder's logic — dispatch it.
+
+1. **`/wp-settings`** — logo, contact info, social links, legal links, copyright, derived
+   from the header/footer/contact content found by `wp-normalize`.
+2. **CPTs first** — for every entry in `contentTypes[]`, run `/wp-cpt <name>` (using its
+   `fields[]` and `seed[]` as the `--from-demo` hints). This must complete before any
+   section queries that CPT.
+3. **`/wp-header`** — the shared header → `header.php` + nav-walker + registered menus.
+4. **`/wp-footer`** — the shared footer → `footer.php`.
+5. **Home page sections** — for the `pages[role=home]` entry, walk its `sections[]` in
+   order and run the `/wp-section` procedure per section:
+   - `kind: "static"` → normal `/wp-section <name>` (three-agent parallel dispatch).
+   - `kind: "cpt-teaser"` → `/wp-section <name>` scoped to query the section's `cpt` via
+     `WP_Query` rather than holding repeater fields (per that CPT's teaser, already
+     scaffolded by its `/wp-cpt` run in step 2 — do not duplicate fields).
+   - `kind: "contact"` → `/wp-section <name> --cf7`.
+6. **Inner pages** — for every `pages[role=inner]` entry: run `/wp-page custom <slug>`,
+   then its `sections[]` through the same per-kind logic as step 5. Under `--careful`,
+   confirm with the user before building each inner page.
+7. **`cpt-archive` pages** — no WP Page is created for these (their archive URL is
+   `has_archive`, already wired by `/wp-cpt` in step 2). Skip page creation; note them in
+   the final report as "archive of `<cpt>`, built by /wp-cpt".
+8. **Blog** — if any `pages[role=blog]` entry exists, run `/wp-page blog`.
+9. **Mandatory system pages — always, regardless of demo content:**
+   - `/wp-page 404`
+   - `/wp-page search`
+   These are never conditional on the demo containing a matching page; they are
+   synthesized from the derived design (shared header/footer, design tokens, section
+   styling) so they read as native to the site.
+
+## Step 5: Phase 3 — Seed & Finish
+
+Run, in order:
+1. **`/wp-seed`** — create WP Pages with matching slugs (so `page-<slug>.php` auto-applies),
+   populate ACF fields from extracted text in the **primary language only** (flag secondary-
+   language strings as untranslated), sideload images into the media library and wire them
+   to fields, build menus from the nav, and create CPT seed posts from each `contentTypes[]`
+   entry's `seed[]`.
+2. **`/wp-finalize`**
+3. **`/wp-polish`**
+4. **`/wp-responsive-check`**
+
+## Step 6: Report
+
+Print a summary:
+```
+=== WP YOLO Build Complete ===
+Pages built:       <slug list, with section counts>
+CPTs registered:   <name list, with archive/single status and seed count>
+CF7 forms:         <count, if any contact sections were found>
+Media imported:    <count>
+Mandatory pages:   404, search (always built)
+
+Review:
+  - <every review[] entry from the manifest — low-confidence splits, CPT-vs-repeater
+    verdicts, ambiguous fields>
+  - <untranslated secondary-language strings, if any>
+  - <anything skipped — e.g. JS-only interactivity not reproducible in static templates>
+```
+
+Note for the user: `--yolo` is best used **after** one checkpointed dry-run of the same
+demo folder, once the manifest has been reviewed and edited at least once.

--- a/commands/wp-yolo.md
+++ b/commands/wp-yolo.md
@@ -71,19 +71,30 @@ Drive the existing commands/agents in this exact order, reading everything from 
    from the header/footer/contact content found by `wp-normalize`.
 2. **CPTs first** — for every entry in `contentTypes[]`, run `/wp-cpt <name>` (using its
    `fields[]` and `seed[]` as the `--from-demo` hints). This must complete before any
-   section queries that CPT.
+   section queries that CPT. **`/wp-cpt` OWNS this CPT's teaser** (`template-parts/section-<name>.php`,
+   named for the CPT — never the manifest section name — injected into `front-page.php`).
+   Pass **`--no-teaser`** when the contentType has `hasTeaser: false`, OR when no
+   `sections[].kind == "cpt-teaser"` with `cpt == <name>` exists anywhere in the manifest —
+   otherwise let `/wp-cpt` build the teaser.
 3. **`/wp-header`** — the shared header → `header.php` + nav-walker + registered menus.
 4. **`/wp-footer`** — the shared footer → `footer.php`.
 5. **Home page sections** — for the `pages[role=home]` entry, walk its `sections[]` in
-   order and run the `/wp-section` procedure per section:
+   order and run the `/wp-section` procedure per section (defaults: `--page index`,
+   `--target front-page.php`, so no flags are needed for home):
    - `kind: "static"` → normal `/wp-section <name>` (three-agent parallel dispatch).
-   - `kind: "cpt-teaser"` → `/wp-section <name>` scoped to query the section's `cpt` via
-     `WP_Query` rather than holding repeater fields (per that CPT's teaser, already
-     scaffolded by its `/wp-cpt` run in step 2 — do not duplicate fields).
+   - `kind: "cpt-teaser"` → **SKIP** — do NOT dispatch `/wp-section` for these. The CPT's
+     teaser `template-parts/section-<cpt>.php` was already built and injected into
+     `front-page.php` by that CPT's `/wp-cpt` run in step 2. Note it in the report as
+     "teaser for `<cpt>`, built by /wp-cpt".
    - `kind: "contact"` → `/wp-section <name> --cf7`.
 6. **Inner pages** — for every `pages[role=inner]` entry: run `/wp-page custom <slug>`,
-   then its `sections[]` through the same per-kind logic as step 5. Under `--careful`,
-   confirm with the user before building each inner page.
+   then build its `sections[]` — but each inner section must read from its OWN demo page
+   and inject into its OWN page template, so pass `--page <slug> --target page-<slug>.php`
+   on every dispatch:
+   - `kind: "static"` → `/wp-section <name> --page <slug> --target page-<slug>.php`.
+   - `kind: "contact"` → `/wp-section <name> --cf7 --page <slug> --target page-<slug>.php`.
+   - `kind: "cpt-teaser"` on an inner page → same skip rule as step 5 (owned by `/wp-cpt`).
+   Under `--careful`, confirm with the user before building each inner page.
 7. **`cpt-archive` pages** — no WP Page is created for these (their archive URL is
    `has_archive`, already wired by `/wp-cpt` in step 2). Skip page creation; note them in
    the final report as "archive of `<cpt>`, built by /wp-cpt".
@@ -98,14 +109,21 @@ Drive the existing commands/agents in this exact order, reading everything from 
 ## Step 5: Phase 3 — Seed & Finish
 
 Run, in order:
-1. **`/wp-seed`** — create WP Pages with matching slugs (so `page-<slug>.php` auto-applies),
-   populate ACF fields from extracted text in the **primary language only** (flag secondary-
-   language strings as untranslated), sideload images into the media library and wire them
-   to fields, build menus from the nav, and create CPT seed posts from each `contentTypes[]`
-   entry's `seed[]`.
-2. **`/wp-finalize`**
-3. **`/wp-polish`**
-4. **`/wp-responsive-check`**
+1. **`/wp-seed --exclude-slugs <slugs>`** — create WP Pages with matching slugs (so
+   `page-<slug>.php` auto-applies), populate ACF fields from extracted text in the
+   **primary language only** (flag secondary-language strings as untranslated), sideload
+   images into the media library and wire them to fields, and build menus from the nav.
+   Set `--exclude-slugs` to the comma-joined slugs of every `pages[role=cpt-archive]` entry
+   (e.g. `--exclude-slugs team`) so no stray WP Page is created for an archive slug — its
+   URL comes from `has_archive`, and a WP Page would collide with `archive-<cpt>.php`.
+2. **Create CPT posts** — `/wp-seed` does not create CPT posts, so after it, for each
+   `contentTypes[]` entry execute its seeder `inc/seed/<name>.php` (emitted by that CPT's
+   `/wp-cpt` run in Phase 2) via the project's WP-CLI wrapper — e.g.
+   `$WP eval-file inc/seed/team.php` — to create that type's posts from its `seed[]`.
+   **Primary language only.**
+3. **`/wp-finalize`**
+4. **`/wp-polish`**
+5. **`/wp-responsive-check`**
 
 ## Step 6: Report
 

--- a/tests/checks/wp-cpt.sh
+++ b/tests/checks/wp-cpt.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+f=commands/wp-cpt.md
+test -f "$f" || { echo "FAIL: $f missing"; exit 1; }
+head -1 "$f" | grep -q '^---$' || { echo "FAIL: no frontmatter"; exit 1; }
+grep -q 'allowed-tools:' "$f" || { echo "FAIL: no allowed-tools"; exit 1; }
+grep -q 'argument-hint:' "$f" || { echo "FAIL: no argument-hint"; exit 1; }
+for token in register_post_type 'inc/post-types' 'archive-' 'single-' has_archive get_post_type_archive_link 'wp-acf' 'wp-template'; do
+  grep -q "$token" "$f" || { echo "FAIL: missing '$token'"; exit 1; }
+done
+echo PASS

--- a/tests/checks/wp-normalize.sh
+++ b/tests/checks/wp-normalize.sh
@@ -4,7 +4,7 @@ f=agents/wp-normalize.md
 test -f "$f" || { echo "FAIL: $f missing"; exit 1; }
 grep -q '^name: wp-normalize$' "$f" || { echo "FAIL: name frontmatter"; exit 1; }
 grep -q '^tools:' "$f" || { echo "FAIL: tools frontmatter"; exit 1; }
-for token in 'SECTION:' '.yolo-manifest.json' 'confidence' 'has_archive' 'View all\|Show more\|See all' 'static-repeater\|repeater' 'contentTypes'; do
+for token in 'SECTION:' '.yolo-manifest.json' 'confidence' 'has_archive' 'View all|Show more|See all' 'static-repeater|repeater' 'contentTypes'; do
   grep -Eq "$token" "$f" || { echo "FAIL: missing '$token'"; exit 1; }
 done
 echo PASS

--- a/tests/checks/wp-normalize.sh
+++ b/tests/checks/wp-normalize.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+f=agents/wp-normalize.md
+test -f "$f" || { echo "FAIL: $f missing"; exit 1; }
+grep -q '^name: wp-normalize$' "$f" || { echo "FAIL: name frontmatter"; exit 1; }
+grep -q '^tools:' "$f" || { echo "FAIL: tools frontmatter"; exit 1; }
+for token in 'SECTION:' '.yolo-manifest.json' 'confidence' 'has_archive' 'View all\|Show more\|See all' 'static-repeater\|repeater' 'contentTypes'; do
+  grep -Eq "$token" "$f" || { echo "FAIL: missing '$token'"; exit 1; }
+done
+echo PASS

--- a/tests/checks/wp-page-search.sh
+++ b/tests/checks/wp-page-search.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+f=commands/wp-page.md
+grep -q 'search' <(grep -i 'Types:' "$f") || { echo "FAIL: search not in Types list"; exit 1; }
+grep -q '### Type: search' "$f" || { echo "FAIL: no '### Type: search' dispatch section"; exit 1; }
+echo PASS

--- a/tests/checks/wp-yolo.sh
+++ b/tests/checks/wp-yolo.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+f=commands/wp-yolo.md
+test -f "$f" || { echo "FAIL: $f missing"; exit 1; }
+grep -q 'argument-hint:' "$f" || { echo "FAIL: frontmatter"; exit 1; }
+for token in 'wp-normalize' 'yolo-manifest' 'checkpoint' '--yolo' '--careful' 'wp-cpt' 'wp-settings' 'wp-header' 'wp-footer' 'wp-section' 'wp-page 404' 'wp-page search' 'wp-seed' 'wp-finalize' 'Review'; do
+  grep -q -- "$token" "$f" || { echo "FAIL: missing '$token'"; exit 1; }
+done
+# every referenced command/agent file must exist
+for name in wp-normalize; do test -f "agents/$name.md" || { echo "FAIL: agents/$name.md"; exit 1; }; done
+for name in wp-cpt wp-settings wp-header wp-footer wp-section wp-page wp-seed wp-finalize wp-polish wp-responsive-check; do test -f "commands/$name.md" || { echo "FAIL: commands/$name.md"; exit 1; }; done
+echo PASS

--- a/tests/fixtures/demo-acme/EXPECTED-BUILD.md
+++ b/tests/fixtures/demo-acme/EXPECTED-BUILD.md
@@ -1,0 +1,93 @@
+# Expected `/wp-yolo` Phase 2 Build Trace — demo-acme
+
+Hand-traced build order for `/wp-yolo tests/fixtures/demo-acme` over
+`EXPECTED-MANIFEST.json`, per `commands/wp-yolo.md` Step 4 ("Phase 2 — Build").
+No agents were run; this is the order the orchestrator's documented steps
+produce when read against this specific manifest.
+
+## Phase 1 + checkpoint (for context, not build order)
+
+1. `wp-normalize` dispatched against `tests/fixtures/demo-acme` → emits
+   `demo/*.html` + `demo/.yolo-manifest.json` (== `EXPECTED-MANIFEST.json`).
+2. Checkpoint (default mode, no `--yolo`): prints pages/sections/confidence,
+   shared header/footer flags, `contentTypes[]`, and the `review[]` list above.
+   User approves as-is (no edits needed for this trace).
+
+## Phase 2 — Build, in the exact order `wp-yolo.md` Step 4 specifies
+
+1. **`/wp-settings`** — logo "Acme Co", nav links, footer copyright text,
+   contact email/message labels — derived from header/footer/contact content.
+
+2. **CPTs first — `contentTypes[]` loop:**
+   - `/wp-cpt team --from-demo team-teaser` — registers the `team` CPT
+     (`has_archive: true`), fields (`photo`, `role`, `bio`; title = person name),
+     `archive-team.php`, `single-team.php`, `template-parts/team/card.php`,
+     the `team` teaser query-section (`template-parts/section-team.php` +
+     `fields/section-team.php`), and the seed helper for the 6 `seed[]` entries.
+   - **This step MUST complete before any section that queries `team`.**
+     It runs before the home page's `team-teaser` section (step 5 below) and
+     before `archive-team.php` is treated as "already built" in step 7 — both
+     of which depend on the CPT being registered and its teaser/card templates
+     existing first. Confirmed: CPT loop is step 2, home sections are step 5.
+
+3. **`/wp-header`** — shared header (identical across all 5 pages, per
+   `shared.header: true`, `headerDivergentPages: []`) → `header.php` +
+   nav-walker + registered "primary" menu (Home/About/Team/Services/Contact).
+
+4. **`/wp-footer`** — shared footer (identical across all pages,
+   `shared.footer: true`, `footerDivergentPages: []`) → `footer.php`.
+
+5. **Home page sections** (`pages[slug=index, role=home].sections[]`, in order):
+   1. `hero` → `kind: static` → normal `/wp-section hero`.
+   2. `about-teaser` → `kind: static` → normal `/wp-section about-teaser`.
+   3. `team-teaser` → `kind: cpt-teaser`, `cpt: team` → `/wp-section team-teaser`
+      scoped to `WP_Query(post_type=team)`, reusing `template-parts/team/card.php`
+      and the `section-team` chrome fields already scaffolded by `/wp-cpt team`
+      in step 2 — no new repeater fields duplicated here.
+   4. `services` → `kind: static` → normal `/wp-section services` (3 static cards).
+
+6. **Inner pages** (`pages[role=inner]`: `about`, `services`, `contact`):
+   - `/wp-page custom about` → sections `about-story`, `about-values`
+     (both `kind: static` → normal `/wp-section`).
+   - `/wp-page custom services` → sections `services-detail`, `services-process`
+     (both `kind: static` → normal `/wp-section`).
+   - `/wp-page custom contact` → section `contact` → `kind: contact` →
+     **`/wp-section contact --cf7`** — routes through the CF7 form path
+     (`<input type="email">` + `<textarea>` detected by `wp-normalize` as a
+     contact form), not a static section build.
+
+7. **`cpt-archive` pages** (`pages[slug=team, role=cpt-archive]`):
+   - `team.html` → **no `/wp-page custom team` run, no `page-team.php`, no WP
+     Page created.** Its archive URL is `archive-team.php` with `has_archive`,
+     already built by `/wp-cpt team` in step 2. Noted in the final report as
+     "archive of `team`, built by /wp-cpt".
+
+8. **Blog** — no `pages[role=blog]` entry in this manifest → step skipped.
+
+9. **Mandatory system pages — always, regardless of demo content:**
+   - `/wp-page 404` — the fixture has no 404 page; built anyway, synthesized
+     from the shared header/footer/design tokens.
+   - `/wp-page search` — the fixture has no search-results page; built anyway,
+     same synthesis path.
+   These run unconditionally per `wp-yolo.md` Step 4.9 — presence in the demo
+   is irrelevant.
+
+## Phase 3 — Seed & Finish (in order)
+
+1. `/wp-seed` — creates WP Pages for `about`, `services`, `contact` (matching
+   `page-<slug>.php` templates) — **NOT** for `team` (cpt-archive, no page
+   created, confirmed above) — populates ACF fields, sideloads team member
+   photos (`assets/team/*.jpg`) into media, creates the 6 `team` CPT seed
+   posts from `contentTypes[0].seed[]`, and builds the primary nav menu.
+2. `/wp-finalize`
+3. `/wp-polish`
+4. `/wp-responsive-check`
+
+## Assertions checked by this trace
+
+- [x] `/wp-cpt team` runs before the home `team-teaser` section AND before
+      `archive-team.php` is available (both step 2, ahead of steps 5 and 7).
+- [x] `team.html` produces no `page-team.php` and no WP Page (step 7).
+- [x] The `contact` section routes through `--cf7` (step 6, contact page).
+- [x] `/wp-page 404` and `/wp-page search` both run despite neither existing
+      in the fixture (step 9, unconditional).

--- a/tests/fixtures/demo-acme/EXPECTED-BUILD.md
+++ b/tests/fixtures/demo-acme/EXPECTED-BUILD.md
@@ -23,7 +23,12 @@ produce when read against this specific manifest.
      (`has_archive: true`), fields (`photo`, `role`, `bio`; title = person name),
      `archive-team.php`, `single-team.php`, `template-parts/team/card.php`,
      the `team` teaser query-section (`template-parts/section-team.php` +
-     `fields/section-team.php`), and the seed helper for the 6 `seed[]` entries.
+     `fields/section-team.php`, injected into `front-page.php`), and the seed
+     helper `inc/seed/team.php` for the 6 `seed[]` entries.
+   - **NO `--no-teaser`** here: `contentTypes[0].hasTeaser == true` AND a
+     `kind: cpt-teaser` section (`team-teaser`, `cpt: team`) exists, so `/wp-cpt`
+     OWNS and builds the teaser `template-parts/section-team.php` (named for the
+     CPT `team`, not the manifest section name `team-teaser`).
    - **This step MUST complete before any section that queries `team`.**
      It runs before the home page's `team-teaser` section (step 5 below) and
      before `archive-team.php` is treated as "already built" in step 7 — both
@@ -38,23 +43,32 @@ produce when read against this specific manifest.
    `shared.footer: true`, `footerDivergentPages: []`) → `footer.php`.
 
 5. **Home page sections** (`pages[slug=index, role=home].sections[]`, in order):
-   1. `hero` → `kind: static` → normal `/wp-section hero`.
+   1. `hero` → `kind: static` → normal `/wp-section hero`
+      (defaults: `--page index`, `--target front-page.php`).
    2. `about-teaser` → `kind: static` → normal `/wp-section about-teaser`.
-   3. `team-teaser` → `kind: cpt-teaser`, `cpt: team` → `/wp-section team-teaser`
-      scoped to `WP_Query(post_type=team)`, reusing `template-parts/team/card.php`
-      and the `section-team` chrome fields already scaffolded by `/wp-cpt team`
-      in step 2 — no new repeater fields duplicated here.
+   3. `team-teaser` → `kind: cpt-teaser`, `cpt: team` → **SKIPPED — NOT dispatched
+      through `/wp-section`.** Its teaser `template-parts/section-team.php` was
+      already built and injected into `front-page.php` by `/wp-cpt team` in step 2.
+      Reported as "teaser for `team`, built by /wp-cpt".
    4. `services` → `kind: static` → normal `/wp-section services` (3 static cards).
 
-6. **Inner pages** (`pages[role=inner]`: `about`, `services`, `contact`):
-   - `/wp-page custom about` → sections `about-story`, `about-values`
-     (both `kind: static` → normal `/wp-section`).
+6. **Inner pages** (`pages[role=inner]`: `about`, `services`, `contact`) — every
+   inner section reads from its OWN demo page and injects into its OWN template,
+   so each dispatch carries `--page <slug> --target page-<slug>.php`:
+   - `/wp-page custom about` → sections `about-story`, `about-values` (both
+     `kind: static`) → **`/wp-section about-story --page about --target page-about.php`**
+     and **`/wp-section about-values --page about --target page-about.php`**. This is
+     the C1 contract: without `--page about` the section would be sought in
+     `demo/index.html` (not found → stall), and without `--target page-about.php`
+     it would be injected into `front-page.php` instead of the About page.
    - `/wp-page custom services` → sections `services-detail`, `services-process`
-     (both `kind: static` → normal `/wp-section`).
+     (both `kind: static`) → `/wp-section services-detail --page services --target page-services.php`
+     and `/wp-section services-process --page services --target page-services.php`.
    - `/wp-page custom contact` → section `contact` → `kind: contact` →
-     **`/wp-section contact --cf7`** — routes through the CF7 form path
-     (`<input type="email">` + `<textarea>` detected by `wp-normalize` as a
-     contact form), not a static section build.
+     **`/wp-section contact --cf7 --page contact --target page-contact.php`** —
+     routes through the CF7 form path (`<input type="email">` + `<textarea>`
+     detected by `wp-normalize` as `kind: contact`), reading from `demo/contact.html`
+     and injecting into `page-contact.php`.
 
 7. **`cpt-archive` pages** (`pages[slug=team, role=cpt-archive]`):
    - `team.html` → **no `/wp-page custom team` run, no `page-team.php`, no WP
@@ -74,14 +88,22 @@ produce when read against this specific manifest.
 
 ## Phase 3 — Seed & Finish (in order)
 
-1. `/wp-seed` — creates WP Pages for `about`, `services`, `contact` (matching
-   `page-<slug>.php` templates) — **NOT** for `team` (cpt-archive, no page
-   created, confirmed above) — populates ACF fields, sideloads team member
-   photos (`assets/team/*.jpg`) into media, creates the 6 `team` CPT seed
-   posts from `contentTypes[0].seed[]`, and builds the primary nav menu.
-2. `/wp-finalize`
-3. `/wp-polish`
-4. `/wp-responsive-check`
+1. **`/wp-seed --exclude-slugs team`** — creates WP Pages for `about`, `services`,
+   `contact` (matching `page-<slug>.php` templates) — **NOT** for `team`: it is a
+   `cpt-archive` slug, so it is passed to `--exclude-slugs` and no WP Page is
+   created (its URL comes from `has_archive`; a WP Page would collide with
+   `archive-team.php`). Populates ACF fields, sideloads team member photos
+   (`assets/team/*.jpg`) into media, and builds the primary nav menu.
+   `/wp-seed` does **NOT** create CPT posts.
+2. **Create CPT posts** — for `contentTypes[0]` (`team`), execute its seeder
+   `inc/seed/team.php` (emitted by `/wp-cpt team` in Phase 2) via the WP-CLI
+   wrapper (`$WP eval-file inc/seed/team.php`) to create the 6 `team` posts from
+   `contentTypes[0].seed[]`. Primary language only. This is the executor the
+   whole pipeline relies on for CPT content — neither `/wp-seed` nor `/wp-cpt`
+   creates these posts on its own.
+3. `/wp-finalize`
+4. `/wp-polish`
+5. `/wp-responsive-check`
 
 ## Assertions checked by this trace
 

--- a/tests/fixtures/demo-acme/EXPECTED-MANIFEST.json
+++ b/tests/fixtures/demo-acme/EXPECTED-MANIFEST.json
@@ -1,0 +1,176 @@
+{
+  "source": "tests/fixtures/demo-acme",
+  "pages": [
+    {
+      "slug": "index",
+      "role": "home",
+      "file": "demo/index.html",
+      "sections": [
+        {
+          "name": "hero",
+          "kind": "static",
+          "confidence": 1.0,
+          "fields": [
+            { "name": "hero_title", "type": "text" },
+            { "name": "hero_subtitle", "type": "textarea" }
+          ],
+          "assets": []
+        },
+        {
+          "name": "about-teaser",
+          "kind": "static",
+          "confidence": 1.0,
+          "fields": [
+            { "name": "about_heading", "type": "text" },
+            { "name": "about_intro", "type": "textarea" }
+          ],
+          "assets": []
+        },
+        {
+          "name": "team-teaser",
+          "kind": "cpt-teaser",
+          "cpt": "team",
+          "confidence": 0.95,
+          "rationale": "'View all team' link -> team.html; dedicated team.html full grid exists; collection-noun 'team'; cards have rich per-item data (photo+name+role); same card type appears on 2 pages (home teaser + team.html archive)",
+          "fields": [
+            { "name": "team_heading", "type": "text" },
+            { "name": "team_intro", "type": "textarea" }
+          ],
+          "assets": [
+            "assets/team/john.jpg",
+            "assets/team/jane.jpg",
+            "assets/team/mo.jpg"
+          ]
+        },
+        {
+          "name": "services",
+          "kind": "static",
+          "confidence": 0.85,
+          "rationale": "only 3 fixed cards, no outbound links to detail pages, no dedicated per-card listing separate from services.html's own static sections -- structural feature-card group, not a collection",
+          "fields": [
+            { "name": "services_heading", "type": "text" },
+            { "name": "service_card_title", "type": "text" },
+            { "name": "service_card_text", "type": "textarea" }
+          ],
+          "assets": []
+        }
+      ]
+    },
+    {
+      "slug": "about",
+      "role": "inner",
+      "file": "demo/about.html",
+      "sections": [
+        {
+          "name": "about-story",
+          "kind": "static",
+          "confidence": 1.0,
+          "fields": [
+            { "name": "about_story_title", "type": "text" },
+            { "name": "about_story_body", "type": "textarea" }
+          ],
+          "assets": []
+        },
+        {
+          "name": "about-values",
+          "kind": "static",
+          "confidence": 1.0,
+          "fields": [
+            { "name": "about_values_heading", "type": "text" },
+            { "name": "about_values_body", "type": "textarea" }
+          ],
+          "assets": []
+        }
+      ]
+    },
+    {
+      "slug": "services",
+      "role": "inner",
+      "file": "demo/services.html",
+      "sections": [
+        {
+          "name": "services-detail",
+          "kind": "static",
+          "confidence": 1.0,
+          "fields": [
+            { "name": "services_detail_title", "type": "text" },
+            { "name": "services_detail_body", "type": "textarea" }
+          ],
+          "assets": []
+        },
+        {
+          "name": "services-process",
+          "kind": "static",
+          "confidence": 1.0,
+          "fields": [
+            { "name": "services_process_heading", "type": "text" },
+            { "name": "services_process_body", "type": "textarea" }
+          ],
+          "assets": []
+        }
+      ]
+    },
+    {
+      "slug": "contact",
+      "role": "inner",
+      "file": "demo/contact.html",
+      "sections": [
+        {
+          "name": "contact",
+          "kind": "contact",
+          "confidence": 1.0,
+          "fields": [
+            { "name": "contact_heading", "type": "text" },
+            { "name": "contact_email_field_label", "type": "text" },
+            { "name": "contact_message_field_label", "type": "text" }
+          ],
+          "assets": []
+        }
+      ]
+    },
+    {
+      "slug": "team",
+      "role": "cpt-archive",
+      "file": "demo/team.html",
+      "cpt": "team",
+      "sections": []
+    }
+  ],
+  "shared": {
+    "header": true,
+    "footer": true,
+    "headerDivergentPages": [],
+    "footerDivergentPages": []
+  },
+  "contentTypes": [
+    {
+      "name": "team",
+      "fields": [
+        { "name": "photo", "type": "image" },
+        { "name": "role", "type": "text" },
+        { "name": "bio", "type": "textarea" }
+      ],
+      "hasTeaser": true,
+      "seed": [
+        { "name": "John Smith", "role": "Founder", "photo": "assets/team/john.jpg",
+          "bio": "John started Acme Co in 1998 with a single workshop.", "source": "team.html" },
+        { "name": "Jane Doe", "role": "Lead Designer", "photo": "assets/team/jane.jpg",
+          "bio": "Jane leads all brand and product design work.", "source": "team.html" },
+        { "name": "Mo Ali", "role": "Operations", "photo": "assets/team/mo.jpg",
+          "bio": "Mo keeps projects on time and on budget.", "source": "team.html" },
+        { "name": "Sara Lee", "role": "Senior Consultant", "photo": "assets/team/sara.jpg",
+          "bio": "Sara advises clients on long-term strategy.", "source": "team.html" },
+        { "name": "Tom Reyes", "role": "Support Lead", "photo": "assets/team/tom.jpg",
+          "bio": "Tom runs our client support and care plans.", "source": "team.html" },
+        { "name": "Amy Chen", "role": "Designer", "photo": "assets/team/amy.jpg",
+          "bio": "Amy works across brand and digital design.", "source": "team.html" }
+      ]
+    }
+  ],
+  "review": [
+    "home 'team' section classified cpt-teaser at confidence 0.95 -- 'View all team' link plus dedicated team.html archive make this a slam-dunk, listed for visibility only",
+    "home 'services' section classified static-repeater at confidence 0.85 -- only 3 fixed cards with no outbound detail links, but flagged because it sits next to a CPT-classified group on the same page and the boundary is a judgment call",
+    "all sections on inner pages (about, services, contact) derived from heuristic segmentation of implicit <section> boundaries rather than explicit id/class naming beyond the section element itself -- field names are inferred, not literal",
+    "contentTypes.team.fields omits a 'name' field because the person's name maps to the WP post title (wp-cpt.md: 'usually the post title, skip if so') -- confirm at checkpoint that no separate name field is wanted"
+  ]
+}

--- a/tests/fixtures/demo-acme/about.html
+++ b/tests/fixtures/demo-acme/about.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Acme Co — About</title>
+  <link rel="stylesheet" href="assets/styles.css">
+</head>
+<body>
+
+<header class="site-header">
+  <div class="site-header__logo">Acme Co</div>
+  <nav class="site-header__nav">
+    <a href="index.html">Home</a>
+    <a href="about.html">About</a>
+    <a href="team.html">Team</a>
+    <a href="services.html">Services</a>
+    <a href="contact.html">Contact</a>
+  </nav>
+</header>
+
+<section class="about-story">
+  <h1>Our Story</h1>
+  <p>Founded in 1998, Acme Co started as a two-person workshop and grew into a
+  full-service studio without losing its craft-first roots.</p>
+</section>
+
+<section class="about-values">
+  <h2>What We Value</h2>
+  <p>Quality, honesty, and long-term relationships over quick wins.</p>
+</section>
+
+<footer class="site-footer">
+  <p>&copy; 2026 Acme Co. All rights reserved.</p>
+</footer>
+
+</body>
+</html>

--- a/tests/fixtures/demo-acme/assets/styles.css
+++ b/tests/fixtures/demo-acme/assets/styles.css
@@ -1,0 +1,35 @@
+:root {
+  --color-primary: #1b3a4b;
+  --color-accent: #e0a458;
+  --color-bg: #ffffff;
+  --color-text: #222831;
+  --font-heading: 'Poppins', sans-serif;
+  --font-body: 'Inter', sans-serif;
+  --space-md: 1.5rem;
+  --space-lg: 3rem;
+}
+
+body { font-family: var(--font-body); color: var(--color-text); background: var(--color-bg); margin: 0; }
+h1, h2, h3 { font-family: var(--font-heading); }
+
+.site-header { display: flex; justify-content: space-between; align-items: center; padding: var(--space-md); background: var(--color-primary); color: #fff; }
+.site-header__nav a { color: #fff; margin-left: var(--space-md); text-decoration: none; }
+
+.hero { padding: var(--space-lg); text-align: center; background: #f4f6f8; }
+
+.about-teaser { padding: var(--space-lg); max-width: 720px; margin: 0 auto; }
+
+.team-teaser { padding: var(--space-lg); background: #fafafa; }
+.team-teaser__grid { display: flex; gap: var(--space-md); justify-content: center; }
+.team-card { width: 220px; text-align: center; }
+.team-card img { width: 100%; border-radius: 50%; }
+
+.services { padding: var(--space-lg); }
+.services__grid { display: flex; gap: var(--space-md); }
+.service-card { flex: 1; padding: var(--space-md); border: 1px solid #eee; }
+
+.site-footer { padding: var(--space-lg); background: var(--color-primary); color: #fff; text-align: center; }
+
+.team-archive__grid { display: flex; flex-wrap: wrap; gap: var(--space-md); }
+
+.contact-form input, .contact-form textarea { display: block; width: 100%; margin-bottom: var(--space-md); padding: 0.5rem; }

--- a/tests/fixtures/demo-acme/contact.html
+++ b/tests/fixtures/demo-acme/contact.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Acme Co — Contact</title>
+  <link rel="stylesheet" href="assets/styles.css">
+</head>
+<body>
+
+<header class="site-header">
+  <div class="site-header__logo">Acme Co</div>
+  <nav class="site-header__nav">
+    <a href="index.html">Home</a>
+    <a href="about.html">About</a>
+    <a href="team.html">Team</a>
+    <a href="services.html">Services</a>
+    <a href="contact.html">Contact</a>
+  </nav>
+</header>
+
+<section class="contact">
+  <h1>Get in Touch</h1>
+  <form class="contact-form">
+    <input type="text" name="name" placeholder="Your name">
+    <input type="email" name="email" placeholder="Your email">
+    <textarea name="message" placeholder="Your message"></textarea>
+    <button type="submit">Send</button>
+  </form>
+</section>
+
+<footer class="site-footer">
+  <p>&copy; 2026 Acme Co. All rights reserved.</p>
+</footer>
+
+</body>
+</html>

--- a/tests/fixtures/demo-acme/index.html
+++ b/tests/fixtures/demo-acme/index.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Acme Co — Home</title>
+  <link rel="stylesheet" href="assets/styles.css">
+</head>
+<body>
+
+<header class="site-header">
+  <div class="site-header__logo">Acme Co</div>
+  <nav class="site-header__nav">
+    <a href="index.html">Home</a>
+    <a href="about.html">About</a>
+    <a href="team.html">Team</a>
+    <a href="services.html">Services</a>
+    <a href="contact.html">Contact</a>
+  </nav>
+</header>
+
+<section class="hero">
+  <h1>We build things that last</h1>
+  <p>Acme Co has been delivering craftsmanship since 1998.</p>
+</section>
+
+<section class="about-teaser">
+  <h2>About Us</h2>
+  <p>Acme Co is a family-run studio focused on quality over hype. Read our full story on the About page.</p>
+</section>
+
+<section class="team-teaser">
+  <h2>Meet the Team</h2>
+  <div class="team-teaser__grid">
+    <div class="team-card">
+      <img src="assets/team/john.jpg" alt="John Smith">
+      <h3>John Smith</h3>
+      <p>Founder</p>
+    </div>
+    <div class="team-card">
+      <img src="assets/team/jane.jpg" alt="Jane Doe">
+      <h3>Jane Doe</h3>
+      <p>Lead Designer</p>
+    </div>
+    <div class="team-card">
+      <img src="assets/team/mo.jpg" alt="Mo Ali">
+      <h3>Mo Ali</h3>
+      <p>Operations</p>
+    </div>
+  </div>
+  <a href="team.html" class="team-teaser__link">View all team</a>
+</section>
+
+<section class="services">
+  <h2>Our Services</h2>
+  <div class="services__grid">
+    <div class="service-card">
+      <h3>Consulting</h3>
+      <p>Strategy sessions tailored to your goals.</p>
+    </div>
+    <div class="service-card">
+      <h3>Design</h3>
+      <p>End-to-end brand and product design.</p>
+    </div>
+    <div class="service-card">
+      <h3>Support</h3>
+      <p>Ongoing maintenance and care plans.</p>
+    </div>
+  </div>
+</section>
+
+<footer class="site-footer">
+  <p>&copy; 2026 Acme Co. All rights reserved.</p>
+</footer>
+
+</body>
+</html>

--- a/tests/fixtures/demo-acme/services.html
+++ b/tests/fixtures/demo-acme/services.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Acme Co — Services</title>
+  <link rel="stylesheet" href="assets/styles.css">
+</head>
+<body>
+
+<header class="site-header">
+  <div class="site-header__logo">Acme Co</div>
+  <nav class="site-header__nav">
+    <a href="index.html">Home</a>
+    <a href="about.html">About</a>
+    <a href="team.html">Team</a>
+    <a href="services.html">Services</a>
+    <a href="contact.html">Contact</a>
+  </nav>
+</header>
+
+<section class="services-detail">
+  <h1>Services</h1>
+  <p>We offer consulting, design, and ongoing support engagements.</p>
+</section>
+
+<section class="services-process">
+  <h2>How We Work</h2>
+  <p>Discovery, design, delivery, and long-term care — the same four steps every time.</p>
+</section>
+
+<footer class="site-footer">
+  <p>&copy; 2026 Acme Co. All rights reserved.</p>
+</footer>
+
+</body>
+</html>

--- a/tests/fixtures/demo-acme/team.html
+++ b/tests/fixtures/demo-acme/team.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Acme Co — Team</title>
+  <link rel="stylesheet" href="assets/styles.css">
+</head>
+<body>
+
+<header class="site-header">
+  <div class="site-header__logo">Acme Co</div>
+  <nav class="site-header__nav">
+    <a href="index.html">Home</a>
+    <a href="about.html">About</a>
+    <a href="team.html">Team</a>
+    <a href="services.html">Services</a>
+    <a href="contact.html">Contact</a>
+  </nav>
+</header>
+
+<section class="team-archive">
+  <h1>Our Team</h1>
+  <div class="team-archive__grid">
+    <div class="team-card">
+      <img src="assets/team/john.jpg" alt="John Smith">
+      <h3>John Smith</h3>
+      <p>Founder</p>
+      <p>John started Acme Co in 1998 with a single workshop.</p>
+      <a href="#">View profile</a>
+    </div>
+    <div class="team-card">
+      <img src="assets/team/jane.jpg" alt="Jane Doe">
+      <h3>Jane Doe</h3>
+      <p>Lead Designer</p>
+      <p>Jane leads all brand and product design work.</p>
+      <a href="#">View profile</a>
+    </div>
+    <div class="team-card">
+      <img src="assets/team/mo.jpg" alt="Mo Ali">
+      <h3>Mo Ali</h3>
+      <p>Operations</p>
+      <p>Mo keeps projects on time and on budget.</p>
+      <a href="#">View profile</a>
+    </div>
+    <div class="team-card">
+      <img src="assets/team/sara.jpg" alt="Sara Lee">
+      <h3>Sara Lee</h3>
+      <p>Senior Consultant</p>
+      <p>Sara advises clients on long-term strategy.</p>
+      <a href="#">View profile</a>
+    </div>
+    <div class="team-card">
+      <img src="assets/team/tom.jpg" alt="Tom Reyes">
+      <h3>Tom Reyes</h3>
+      <p>Support Lead</p>
+      <p>Tom runs our client support and care plans.</p>
+      <a href="#">View profile</a>
+    </div>
+    <div class="team-card">
+      <img src="assets/team/amy.jpg" alt="Amy Chen">
+      <h3>Amy Chen</h3>
+      <p>Designer</p>
+      <p>Amy works across brand and digital design.</p>
+      <a href="#">View profile</a>
+    </div>
+  </div>
+</section>
+
+<footer class="site-footer">
+  <p>&copy; 2026 Acme Co. All rights reserved.</p>
+</footer>
+
+</body>
+</html>


### PR DESCRIPTION
## Summary

Adds `/wp-yolo` — convert a complete, externally-authored **multi-page HTML demo folder** into a working WordPress theme in one pass, reusing the plugin's existing per-piece build mechanism. Also fills the plugin's long-standing **custom-post-type gap** with a reusable `/wp-cpt` command.

### New surface
- **`/wp-yolo <demo-folder> [--yolo] [--careful]`** — orchestrator. Phase 1 normalize → checkpoint → Phase 2 build (in dependency order) → Phase 3 seed & finish → report. Flag-controlled autonomy.
- **`/wp-cpt <name>`** — custom post type builder: `register_post_type` + ACF fields + `archive-<name>.php` + `single-<name>.php` + optional teaser query-section + a deterministic `inc/seed/<name>.php` seeder. Independently useful for manual builds.
- **`wp-normalize` agent** — reasons over the demo DOM to emit canonical delimited `demo/*.html` + a `.yolo-manifest.json`, splitting sections and classifying each repeating card group as **static-repeater vs custom-post-type** (six-signal rubric + cross-page linkage: a `team.html` listing → CPT archive, not a static page).
- **`/wp-page search`** — new page type. `/wp-yolo` always builds `404` and `search`, design-synthesized from the site's tokens/header/footer even when absent from the demo.

### Extended (backward-compatible)
- `/wp-section` gains `--page <slug>` / `--target <template>` (defaults reproduce today's behavior) so inner-page sections read from their own demo page and inject into their own template.
- `/wp-seed` gains `--exclude-slugs <csv>` so a CPT-archive slug doesn't get a colliding WP Page.

### Verification
This repo is markdown command/agent specs (no runtime code). Verification is grep-based structural checks under `tests/checks/` (all 4 pass) + a hand-traced dry-run oracle under `tests/fixtures/demo-acme/` (multi-page fixture with a team CPT, a contact form, and no 404/search — proving they're built anyway).

### Review trail
Built task-by-task with per-task spec+quality reviews. A whole-branch review caught one Critical + three Important orchestration defects (inner-page section sourcing, CPT teaser/seed ownership, stray archive page); all fixed and re-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
