### PR TITLE
feat: add /wp-context — docs-driven scope & constraints (stacked on #9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## [Unreleased]
 
 ### Added
+- **`/wp-context` command + `wp-context` agent**: reads a project's `docs/` folder (scope spreadsheets, design PDFs, estimate/scope markdown) and extracts a `## Project Constraints` section into `.claude/CLAUDE.md` plus an actionable `docs/.scope-manifest.json`. Auto-runs from `/wp-init` when `docs/` exists.
+- **`embed` page type for `/wp-page`**: styled shell with a marked insertion point for provider-delivered pages (IDX, booking). `/wp-yolo` builds these for `delivery: idx|plugin` scope pages instead of normal templates.
+- **Scope-aware `/wp-yolo`**: reconciles the docs scope manifest with the demo — scope governs which pages to build and how (theme / idx-shell / skip), the demo fills content; out-of-scope and approved-but-missing pages are reported.
 - **`/wp-yolo` command**: converts a complete multi-page HTML demo folder into a WordPress theme in one pass — normalizes the demo, infers pages/sections/fields/content-types, and drives the existing build pipeline. Flag-controlled autonomy (`--yolo`, `--careful`).
 - **`/wp-cpt` command**: custom post type builder — registers a CPT and generates its fields, archive, single, optional teaser query-section, and seed helper.
 - **`wp-normalize` agent**: analyzes an arbitrary demo folder into the plugin's canonical delimited format plus a build manifest, splitting sections and classifying static-repeater vs custom-post-type groups.

--- a/README.md
+++ b/README.md
@@ -89,6 +89,12 @@ Detects available tools (Docker, DDEV, Lando, Nginx, Apache, Caddy, PHP versions
 
 Prompts for project name, slug, languages, industry. Copies the starter theme, replaces placeholders, generates `.claude/CLAUDE.md` with project config. When `.wp-create.json` exists, skips redundant questions and activates the theme via WP-CLI.
 
+**Scope Management:** If a `docs/` folder exists with scope spreadsheets, design PDFs, or estimate markdown, `/wp-init` automatically runs `/wp-context` to extract a scope manifest and project constraints. Re-run manually after updating docs:
+
+```
+/wp-context
+```
+
 ### 2. Create the demo
 
 ```
@@ -229,12 +235,13 @@ Clones a remote/staging WordPress site to local dev. Supports SSH automated mode
 | Command | Description |
 |---------|-------------|
 | `/wp-init` | Scaffold new project from starter theme |
+| `/wp-context` | Extract scope manifest from `docs/` folder and update project constraints |
 | `/wp-demo` | Create demo HTML for client approval |
 | `/wp-polish [path]` | Normalize external HTML into plugin-compatible demo |
 | `/wp-header` | Build header with nav, logo, language switcher |
 | `/wp-footer` | Build footer from settings page fields |
 | `/wp-section <name>` | One-shot section: ACF fields + template + CSS |
-| `/wp-page <type>` | Page template generator (blog, legal, 404, generic, custom, search) |
+| `/wp-page <type>` | Page template generator (blog, legal, 404, generic, custom, search, embed) |
 | `/wp-cpt <name>` | Custom post type builder — generates fields, archive, single, seed helper |
 | `/wp-yolo <demo-folder>` | Convert complete demo folder to WordPress theme in one pass |
 | `/wp-settings` | Extend the settings page with new fields |

--- a/README.md
+++ b/README.md
@@ -89,11 +89,40 @@ Detects available tools (Docker, DDEV, Lando, Nginx, Apache, Caddy, PHP versions
 
 Prompts for project name, slug, languages, industry. Copies the starter theme, replaces placeholders, generates `.claude/CLAUDE.md` with project config. When `.wp-create.json` exists, skips redundant questions and activates the theme via WP-CLI.
 
-**Scope Management:** If a `docs/` folder exists with scope spreadsheets, design PDFs, or estimate markdown, `/wp-init` automatically runs `/wp-context` to extract a scope manifest and project constraints. Re-run manually after updating docs:
+### 1b. Gather project scope from `docs/`
+
+If the project has a `docs/` folder with client documents, `/wp-init` automatically runs
+`/wp-context` to read them. You can also run it (or re-run it after docs change) manually:
 
 ```
-/wp-context
+/wp-context            # reads ./docs
+/wp-context path/to/docs
 ```
+
+**What to put in `docs/`** — any mix of: scope spreadsheets (`.xlsx` / `.ods`), the design
+package (`.pdf`), estimate/scope notes (`.md`), emails, and link lists (`.txt`). Example:
+a "Pages in scope / Design provided" table, an IDX provider requirement, and hosting/forms/SEO
+constraints.
+
+**What it produces** — two artifacts consumed by the rest of the pipeline:
+
+1. A `## Project Constraints` section written into `.claude/CLAUDE.md` (integrations, forms,
+   SEO, hosting, responsive/migration notes) — every later command reads it as guidance.
+2. `docs/.scope-manifest.json` — a structured page list where each page is tagged
+   `inScope`, `designProvided`, `approved`, and `delivery` = `theme | idx | plugin`.
+
+**How it drives the build** — when you later run `/wp-yolo`, scope governs *what* and *how*,
+the demo fills *content*:
+
+| Scope says | `/wp-yolo` does |
+|------------|-----------------|
+| in-scope, `delivery: theme`, has demo HTML | builds the page normally |
+| in-scope, `delivery: idx` or `plugin` | builds a styled **shell** (`/wp-page embed`) with a marked insertion point for the provider's shortcode (e.g. Showcase IDX) — not a normal template |
+| in-scope but no demo HTML | reports "approved/designed but no HTML — needs demo" |
+| in the demo but not in scope | skips it and notes it |
+
+Re-run `/wp-context` any time the client updates the scope or design docs — it replaces the
+constraints block and overwrites the manifest idempotently.
 
 ### 2. Create the demo
 

--- a/agents/wp-context.md
+++ b/agents/wp-context.md
@@ -1,0 +1,148 @@
+---
+name: wp-context
+description: Project-docs analyzer — reads a docs/ folder (scope spreadsheets, design PDFs, estimate/scope markdown) and extracts project constraints + an actionable scope manifest
+tools: Read, Write, Edit, Bash, Grep, Glob
+---
+
+# WordPress Project-Docs Analyzer
+
+You read a project's `docs/` folder and turn heterogeneous client documents into
+project context the build pipeline can use: a prose `## Project Constraints` block for
+`.claude/CLAUDE.md` and a structured `docs/.scope-manifest.json`. Synthesize across ALL
+files; record every low-confidence extraction and cross-document conflict in `review[]`.
+
+## Extraction Procedure
+
+Work through every file in the `docs/` folder given to you. Per file type:
+
+- `.md` / `.txt` → Read directly.
+- `.pdf` → Read tool's native PDF `pages` param (design brief, sitemap, mockups). For
+  large or text-only PDFs, fall back to `pdftotext <file> -` via Bash.
+- `.xlsx` / `.ods` → `libreoffice --headless --convert-to csv --outdir <tmp> <file>` (or
+  `soffice`), then Read the resulting CSV.
+- images (`.png`/`.jpg`/`.webp`) → Read (visual reference).
+
+**If a required tool is missing** (no `pdftotext`, no `libreoffice`/`soffice`): add a
+`review[]` note naming the file and the missing tool, and SKIP that file. NEVER fail the
+whole run because one file couldn't be processed.
+
+**Synthesize across all files** — don't treat each document in isolation. For example,
+reconcile `estimate.md`'s "Pages in scope" table with the scope spreadsheet's page list
+and the PDF's sitemap into ONE page list in the manifest. When two sources disagree
+(e.g. spreadsheet says a page is out of scope, `estimate.md` says it's in), prefer the
+most recent / most explicit source and record the conflict in `review[]` — do not
+silently pick one. Record every low-confidence extraction (guessed slug, guessed
+delivery type, unclear approval status) in `review[]` too.
+
+## `docs/.scope-manifest.json` Schema
+
+Emit exactly this key set:
+
+```jsonc
+{
+  "source": "<docs-folder-path>",
+  "pages": [
+    {
+      "name": "<string>",
+      "slug": "<string>",
+      "inScope": true,
+      "designProvided": true,
+      "delivery": "theme" | "idx" | "plugin",
+      "approved": true,
+      "provider": "<string, optional — set when delivery is idx|plugin>",
+      "notes": "<string, optional>"
+    }
+  ],
+  "integrations": [
+    { "name": "<string>", "type": "<string>", "provider": "<string>", "notes": "<string>" }
+  ],
+  "constraints": {
+    "forms": "<string>",
+    "seo": "<string>",
+    "hosting": "<string>",
+    "responsive": "<string>",
+    "migration": "<string>"
+  },
+  "review": [ "<string, one per low-confidence extraction / cross-doc conflict>" ]
+}
+```
+
+Field semantics:
+- `delivery` ∈ `theme | idx | plugin`. `theme` = build a normal template; `idx`/`plugin`
+  = provider-delivered → styled shell (a `/wp-page embed` build, not a normal section
+  build).
+- `inScope`, `designProvided`, `approved` are booleans — omit or set `false` when
+  unknown, and if unknown, add a corresponding `review[]` note.
+- `constraints` is an open object — include whatever categories the docs actually speak
+  to (`forms`, `seo`, `hosting`, `responsive`, `migration`, and any others found); omit
+  categories with no signal rather than guessing.
+- `review[]` holds every low-confidence extraction and every cross-document conflict,
+  in plain language.
+
+### Filled example
+
+```jsonc
+{
+  "source": "docs/",
+  "pages": [
+    { "name": "Home", "slug": "home", "inScope": true, "designProvided": true,
+      "delivery": "theme", "approved": true, "notes": "" },
+    { "name": "Home Search", "slug": "home-search", "inScope": true,
+      "designProvided": true, "delivery": "idx", "provider": "Showcase IDX",
+      "approved": true },
+    { "name": "Listing Detail", "slug": "listing-detail", "inScope": true,
+      "designProvided": false, "delivery": "idx", "provider": "Showcase IDX",
+      "approved": false, "notes": "no mockup provided for this page" }
+  ],
+  "integrations": [
+    { "name": "Showcase IDX", "type": "idx", "provider": "Showcase IDX",
+      "notes": "search, listing detail, map, saved searches, portal — native functionality, styled to design within platform limits" }
+  ],
+  "constraints": {
+    "forms": "email-notification only",
+    "seo": "on-page + XML sitemap",
+    "hosting": "client-hosted production; staging by us; one deploy at launch",
+    "responsive": "tablet/mobile interpreted from desktop — no mobile designs",
+    "migration": "no data/user migration"
+  },
+  "review": [
+    "Listing Detail approval status unclear — estimate.md marks it in-scope but scope.xlsx has no approval column; treated as not approved pending client confirmation"
+  ]
+}
+```
+
+## `## Project Constraints` Prose Block (`.claude/CLAUDE.md`)
+
+Append (or replace) a section wrapped in idempotency markers so re-runs update cleanly:
+
+```markdown
+<!-- wp-context:start -->
+## Project Constraints
+
+- **Scope summary:** …
+- **Integrations:** Showcase IDX (search, listing detail, map, saved searches, portal — native, styled to design).
+- **Forms:** email-notification only.
+- **SEO:** on-page structure + XML sitemap.
+- **Hosting:** client-hosted production; we host staging; one deploy at launch.
+- **Responsive:** tablet/mobile interpreted from desktop — no mobile designs provided.
+- **Migration:** no data/user migration.
+- **Source docs:** <list of files read>
+<!-- wp-context:end -->
+```
+
+**Re-runs REPLACE this block.** When `.claude/CLAUDE.md` already contains a
+`<!-- wp-context:start -->` / `<!-- wp-context:end -->` pair, remove everything between
+them (inclusive of the markers) and write the freshly-generated block in its place —
+never append a second copy, never leave stale bullet points from a previous run.
+
+## Edge Cases (never fail the whole run)
+
+- **No `docs/` folder** → exit cleanly reporting "no docs/ found, nothing to extract."
+  Do not write either artifact.
+- **`docs/` exists but has no scope info** (only images/links) → still write the
+  constraints block with whatever was found, and write a manifest with `"pages": []`
+  plus a `review[]` note explaining no scope data was found.
+- **Missing `pdftotext` / `libreoffice`** → skip only the affected file, add a
+  `review[]` note, keep processing the rest.
+- **Conflicting scope across documents** → prefer the most recent / most explicit
+  source, record the conflict in `review[]`.

--- a/commands/wp-context.md
+++ b/commands/wp-context.md
@@ -1,0 +1,22 @@
+---
+description: Gather project constraints and scope from the docs/ folder — writes a Project Constraints section into CLAUDE.md and an actionable scope manifest
+allowed-tools: Read, Write, Edit, Bash, Grep, Glob, Agent
+argument-hint: "[docs-path]"
+---
+
+# WP Context — Project Docs → Constraints & Scope
+
+## Step 1: Resolve docs path & gate
+- `$ARGUMENTS` first word = docs folder path (default `./docs`).
+- If the folder does not exist: print "No docs/ found at <path> — nothing to extract." and exit 0 (not an error).
+- Read `.claude/CLAUDE.md` for theme slug + languages. If missing, tell the user to run `/wp-init` first and exit.
+
+## Step 2: Extract
+Dispatch the **wp-context** agent against the docs folder. It reads every file (per its format rules) and returns the synthesized constraints + scope.
+
+## Step 3: Write artifacts (idempotent)
+- Replace the `<!-- wp-context:start -->` … `<!-- wp-context:end -->` block in `.claude/CLAUDE.md` with the new `## Project Constraints` section (create it at the end if absent).
+- Write `docs/.scope-manifest.json` (overwrite).
+
+## Step 4: Report
+Print: pages found (in-scope / out / idx-plugin counts), integrations detected, key constraints, and any `review[]` items to confirm.

--- a/commands/wp-init.md
+++ b/commands/wp-init.md
@@ -303,7 +303,14 @@ With:
 1. ~~`/wp-demo`~~ — Demo already exists, skip to /wp-header
 ```
 
-## Step 8: Activate Theme and Install Dependencies
+## Step 8: Gather project docs (if present)
+
+Check if a docs folder exists in the project root. If docs directory exists, run `/wp-context` to extract project
+constraints and the scope manifest now (so every later command — especially `/wp-yolo` —
+builds with the client's approved scope, integrations like IDX, and constraints in context).
+If there is no `docs/` folder, skip this step silently.
+
+## Step 9: Activate Theme and Install Dependencies
 
 ### Custom Fields Plugin
 
@@ -355,7 +362,7 @@ cd <theme-dir> && npm install && npm run build
 ```
 This generates `assets/css/dist/main.css` and `assets/js/dist/index.js` needed for the theme to function.
 
-## Step 9: Print Summary
+## Step 10: Print Summary
 
 Print a summary:
 

--- a/commands/wp-page.md
+++ b/commands/wp-page.md
@@ -1,7 +1,7 @@
 ---
-description: Generate page templates — blog, generic, legal, 404, search, or custom page types
+description: Generate page templates — blog, generic, legal, 404, search, embed, or custom page types
 allowed-tools: Read, Write, Edit, Bash, Grep, Glob, Agent
-argument-hint: "<type> [name] [screenshot-path]"
+argument-hint: "<type> [name] [screenshot-path] [--provider <name>]"
 ---
 
 # WP Page — Page Template Generator
@@ -19,13 +19,14 @@ If no type is provided, print an error:
 ```
 Error: Page type is required.
 Usage: /wp-page <type> [name] [screenshot-path]
-Types: blog, generic, legal, 404, search, custom
+Types: blog, generic, legal, 404, search, embed, custom
 Examples:
   /wp-page blog
   /wp-page generic
   /wp-page legal
   /wp-page 404
   /wp-page search
+  /wp-page embed home-search --provider "Showcase IDX"
   /wp-page custom pricing
 ```
 
@@ -193,6 +194,32 @@ Dispatch **wp-css** agent:
 
 > Add search-results + no-results state CSS to the theme stylesheet within delimiters,
 > using the project's design-system custom properties (no new colors).
+
+---
+
+### Type: embed
+
+For provider-delivered pages (IDX, booking, tours) that are NOT built as normal templates — the third-party plugin supplies the functionality; we supply a styled page with a clear insertion point.
+
+Dispatch **wp-template** agent:
+
+> Generate `page-<slug>.php`:
+> - `get_header()`
+> - Optional page title/intro from `prefix_get_field()` (chrome only)
+> - A styled container `<div class="embed-<slug>">` containing a clearly-marked insertion point:
+>   `<!-- EMBED: <provider> shortcode/block goes here -->`
+> - `get_footer()`
+> - Escape all output; BEM class `.embed-<slug>__*`
+
+Dispatch **wp-acf** agent (optional, chrome only):
+
+> Generate `fields/<slug>.php`: heading/intro/notes fields bound to the `<Slug> Page` template. NOT the provider data. Group key `group_<slug>`.
+
+Dispatch **wp-css** agent:
+
+> Add `.embed-<slug>` container + placeholder styling within delimiters, using design-system custom properties (no new colors).
+
+Print in the summary: `Requires plugin: <provider> — install and configure, then insert its shortcode/block at the marked insertion point.`
 
 ---
 

--- a/commands/wp-page.md
+++ b/commands/wp-page.md
@@ -12,7 +12,8 @@ Generate complete page templates with associated ACF fields and CSS based on the
 
 Parse `$ARGUMENTS`:
 - **First word** = page type (required): `blog`, `generic`, `legal`, `404`, `search`, `embed`, or `custom`
-- **Second word** = name (required only for `custom` type)
+- **Second word** = name/slug (required for `custom` AND `embed` types)
+- **`--provider <name>`** (used by `embed`) = sets the provider name; strip this flag and its value from the arguments before resolving the screenshot path, so it is never treated as the screenshot path
 - **Remaining words** = screenshot path (optional)
 
 If no type is provided, print an error:
@@ -201,9 +202,14 @@ Dispatch **wp-css** agent:
 
 For provider-delivered pages (IDX, booking, tours) that are NOT built as normal templates — the third-party plugin supplies the functionality; we supply a styled page with a clear insertion point.
 
+If `<slug>` is `home` or `front` (the site's front page), the generated template file is
+**`front-page.php`** (WordPress never uses `page-home.php` for a static front page);
+otherwise the file is `page-<slug>.php`. The marked insertion point and container go into
+whichever file applies.
+
 Dispatch **wp-template** agent:
 
-> Generate `page-<slug>.php`:
+> Generate `front-page.php` (if `<slug>` is `home`/`front`) or `page-<slug>.php` (otherwise):
 > - `get_header()`
 > - Optional page title/intro from `prefix_get_field()` (chrome only)
 > - A styled container `<div class="embed-<slug>">` containing a clearly-marked insertion point:

--- a/commands/wp-page.md
+++ b/commands/wp-page.md
@@ -11,7 +11,7 @@ Generate complete page templates with associated ACF fields and CSS based on the
 ## Step 1: Parse Arguments
 
 Parse `$ARGUMENTS`:
-- **First word** = page type (required): `blog`, `generic`, `legal`, `404`, `search`, or `custom`
+- **First word** = page type (required): `blog`, `generic`, `legal`, `404`, `search`, `embed`, or `custom`
 - **Second word** = name (required only for `custom` type)
 - **Remaining words** = screenshot path (optional)
 

--- a/commands/wp-yolo.md
+++ b/commands/wp-yolo.md
@@ -51,10 +51,13 @@ If `docs/.scope-manifest.json` exists, read it and reconcile with the `wp-normal
 manifest by matching pages on slug/name. Annotate each page with `delivery`, `inScope`,
 `approved` from the scope manifest. Determine, per page:
 - in-scope + demo HTML + `delivery: theme` → normal build.
-- in-scope + `delivery: idx` or `plugin` → build a styled shell with `/wp-page embed <slug> --provider <provider>` (NOT a normal section build).
-- in-scope + NO demo HTML → do not build; add to Review: "approved/designed but no HTML — needs demo."
+- in-scope + `delivery: idx` or `plugin` → build a styled shell with `/wp-page embed <slug> --provider <provider>` (NOT a normal section build), regardless of whether demo HTML exists.
+- in-scope + `delivery: theme` + NO demo HTML → do not build; add to Review: "approved/designed but no HTML — needs demo."
 - demo page NOT in scope → skip; add to Review: "in demo but out of scope — skipped."
 Fold `constraints` into the guidance passed to every dispatched agent (e.g. forms = email-only, no mobile designs, SEO scope). If `docs/.scope-manifest.json` is absent, proceed demo-governed (existing behavior).
+
+These rules are evaluated in priority order — `delivery` decides first, so the `idx`/`plugin`
+rule always wins over the no-demo-HTML rule.
 
 ## Step 3: Checkpoint (skipped under --yolo)
 

--- a/commands/wp-yolo.md
+++ b/commands/wp-yolo.md
@@ -45,6 +45,17 @@ page, resolves shared header/footer, splits sections, classifies content types
 
 Read `demo/.yolo-manifest.json` back once the agent completes.
 
+## Step 2.5: Phase 1.5 — Load & reconcile scope
+
+If `docs/.scope-manifest.json` exists, read it and reconcile with the `wp-normalize`
+manifest by matching pages on slug/name. Annotate each page with `delivery`, `inScope`,
+`approved` from the scope manifest. Determine, per page:
+- in-scope + demo HTML + `delivery: theme` → normal build.
+- in-scope + `delivery: idx` or `plugin` → build a styled shell with `/wp-page embed <slug> --provider <provider>` (NOT a normal section build).
+- in-scope + NO demo HTML → do not build; add to Review: "approved/designed but no HTML — needs demo."
+- demo page NOT in scope → skip; add to Review: "in demo but out of scope — skipped."
+Fold `constraints` into the guidance passed to every dispatched agent (e.g. forms = email-only, no mobile designs, SEO scope). If `docs/.scope-manifest.json` is absent, proceed demo-governed (existing behavior).
+
 ## Step 3: Checkpoint (skipped under --yolo)
 
 Unless `--yolo` is set, print the detected map from the manifest:
@@ -52,6 +63,9 @@ Unless `--yolo` is set, print the detected map from the manifest:
   confidence where < 1.0)
 - Shared header/footer flags and any divergent pages
 - Content-type classifications (`contentTypes[]`) with field lists
+- **Scope annotations** (if `docs/.scope-manifest.json` was loaded): each page's
+  `delivery` (theme/idx/plugin), out-of-scope pages skipped, and approved-but-missing-HTML
+  pages awaiting a demo
 - The full `review[]` list of low-confidence decisions
 
 Ask the user to **approve / edit / abort**:
@@ -87,10 +101,13 @@ Drive the existing commands/agents in this exact order, reading everything from 
      `front-page.php` by that CPT's `/wp-cpt` run in step 2. Note it in the report as
      "teaser for `<cpt>`, built by /wp-cpt".
    - `kind: "contact"` → `/wp-section <name> --cf7`.
-6. **Inner pages** — for every `pages[role=inner]` entry: run `/wp-page custom <slug>`,
-   then build its `sections[]` — but each inner section must read from its OWN demo page
-   and inject into its OWN page template, so pass `--page <slug> --target page-<slug>.php`
-   on every dispatch:
+6. **Inner pages** — for every `pages[role=inner]` entry: if the scope reconciliation
+   (Step 2.5) marked this page `delivery: idx` or `delivery: plugin`, skip the normal
+   page/section flow entirely and instead run
+   `/wp-page embed <slug> --provider <provider>` — a styled shell, not a section build.
+   Otherwise, run `/wp-page custom <slug>`, then build its `sections[]` — but each inner
+   section must read from its OWN demo page and inject into its OWN page template, so pass
+   `--page <slug> --target page-<slug>.php` on every dispatch:
    - `kind: "static"` → `/wp-section <name> --page <slug> --target page-<slug>.php`.
    - `kind: "contact"` → `/wp-section <name> --cf7 --page <slug> --target page-<slug>.php`.
    - `kind: "cpt-teaser"` on an inner page → same skip rule as step 5 (owned by `/wp-cpt`).
@@ -135,12 +152,15 @@ CPTs registered:   <name list, with archive/single status and seed count>
 CF7 forms:         <count, if any contact sections were found>
 Media imported:    <count>
 Mandatory pages:   404, search (always built)
+Embed/IDX pages:   <slug list — "install & configure <provider>" for each delivery: idx|plugin page>
 
 Review:
   - <every review[] entry from the manifest — low-confidence splits, CPT-vs-repeater
     verdicts, ambiguous fields>
   - <untranslated secondary-language strings, if any>
   - <anything skipped — e.g. JS-only interactivity not reproducible in static templates>
+  - <out-of-scope pages skipped: "in demo but out of scope — skipped">
+  - <approved-but-missing-HTML pages: "approved/designed but no HTML — needs demo">
 ```
 
 Note for the user: `--yolo` is best used **after** one checkpointed dry-run of the same

--- a/commands/wp-yolo.md
+++ b/commands/wp-yolo.md
@@ -92,9 +92,15 @@ Drive the existing commands/agents in this exact order, reading everything from 
    otherwise let `/wp-cpt` build the teaser.
 3. **`/wp-header`** — the shared header → `header.php` + nav-walker + registered menus.
 4. **`/wp-footer`** — the shared footer → `footer.php`.
-5. **Home page sections** — for the `pages[role=home]` entry, walk its `sections[]` in
-   order and run the `/wp-section` procedure per section (defaults: `--page index`,
-   `--target front-page.php`, so no flags are needed for home):
+5. **Home page sections** — for the `pages[role=home]` entry: if the scope reconciliation
+   (Step 2.5) marked it `delivery: idx` or `delivery: plugin` (rare — e.g. an all-IDX
+   homepage), build it as a styled embed shell instead of assembling sections: dispatch
+   `/wp-page embed home --provider <provider>` (its insertion point lives in
+   `front-page.php`), skip the `sections[]` walk for this page, and note it in the
+   report. Otherwise (`delivery: theme` or no scope manifest), proceed with the normal
+   section walk: walk its `sections[]` in order and run the `/wp-section` procedure per
+   section (defaults: `--page index`, `--target front-page.php`, so no flags are needed
+   for home):
    - `kind: "static"` → normal `/wp-section <name>` (three-agent parallel dispatch).
    - `kind: "cpt-teaser"` → **SKIP** — do NOT dispatch `/wp-section` for these. The CPT's
      teaser `template-parts/section-<cpt>.php` was already built and injected into

--- a/tests/checks/wp-context-agent.sh
+++ b/tests/checks/wp-context-agent.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+f=agents/wp-context.md
+test -f "$f" || { echo "FAIL: $f missing"; exit 1; }
+grep -q '^name: wp-context$' "$f" || { echo "FAIL: name frontmatter"; exit 1; }
+grep -q '^tools:' "$f" || { echo "FAIL: tools frontmatter"; exit 1; }
+for token in 'pdftotext' 'libreoffice' 'convert-to csv' '.scope-manifest.json' 'wp-context:start' 'delivery' 'idx' 'integrations' 'review'; do
+  grep -q "$token" "$f" || { echo "FAIL: missing '$token'"; exit 1; }
+done
+echo PASS

--- a/tests/checks/wp-context.sh
+++ b/tests/checks/wp-context.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+f=commands/wp-context.md
+test -f "$f" || { echo "FAIL: $f missing"; exit 1; }
+grep -q 'allowed-tools:' "$f" || { echo "FAIL: frontmatter"; exit 1; }
+grep -q 'argument-hint:' "$f" || { echo "FAIL: argument-hint"; exit 1; }
+for token in 'wp-context' '.scope-manifest.json' 'wp-context:start' 'Project Constraints' 'docs' '.claude/CLAUDE.md'; do
+  grep -q "$token" "$f" || { echo "FAIL: missing '$token'"; exit 1; }
+done
+test -f agents/wp-context.md || { echo "FAIL: agent missing"; exit 1; }
+echo PASS

--- a/tests/checks/wp-init-context.sh
+++ b/tests/checks/wp-init-context.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+f=commands/wp-init.md
+grep -q 'wp-context' "$f" || { echo "FAIL: wp-init does not reference wp-context"; exit 1; }
+grep -Eq 'docs/? (folder|directory|exists)|if .*docs' "$f" || { echo "FAIL: no docs/ existence condition"; exit 1; }
+echo PASS

--- a/tests/checks/wp-page-embed.sh
+++ b/tests/checks/wp-page-embed.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+f=commands/wp-page.md
+grep -q 'embed' <(grep -i 'Types:' "$f") || { echo "FAIL: embed not in Types list"; exit 1; }
+grep -q '### Type: embed' "$f" || { echo "FAIL: no '### Type: embed' section"; exit 1; }
+grep -q 'EMBED:' "$f" || { echo "FAIL: no marked insertion point"; exit 1; }
+grep -q -- '--provider' "$f" || { echo "FAIL: no --provider flag"; exit 1; }
+echo PASS

--- a/tests/checks/wp-yolo-scope.sh
+++ b/tests/checks/wp-yolo-scope.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+f=commands/wp-yolo.md
+for token in '.scope-manifest.json' 'delivery' 'wp-page embed' 'out of scope' 'reconcile'; do
+  grep -q "$token" "$f" || { echo "FAIL: missing '$token'"; exit 1; }
+done
+grep -Eq 'no demo HTML|no HTML|needs demo' "$f" || { echo "FAIL: no approved-but-missing-HTML handling"; exit 1; }
+echo PASS

--- a/tests/fixtures/docs-sample/EXPECTED-RECONCILE.md
+++ b/tests/fixtures/docs-sample/EXPECTED-RECONCILE.md
@@ -1,0 +1,61 @@
+# Expected `/wp-yolo` Phase 1.5 Reconciliation Trace
+
+## Assumed demo folder contents
+
+- `demo/home.html` — present
+- `demo/home-search.html` — present
+- `demo/services.html` — present (NOT in the scope manifest)
+- `demo/contact.html` — **missing**
+
+For this trace we exercise the four outcomes against `EXPECTED-SCOPE-MANIFEST.json`
+with the demo folder above: Home and Home Search have HTML, Contact (in scope,
+`delivery: theme`) is missing its HTML, and `services.html` exists in the demo but has
+no corresponding entry in `pages[]`. (`about`, also in scope with no demo/no design,
+is out of scope for this trace — it would fire the same "needs demo" outcome as
+Contact.)
+
+## Reconciliation, page by page
+
+### 1. Home — in-scope + demo HTML + `delivery: theme` → normal build
+
+`home` is `inScope: true`, `approved: true`, `delivery: theme`, and `demo/home.html`
+exists. Per `commands/wp-yolo.md` Step 2.5 rule 1: dispatched as a normal
+`/wp-section` build (home role, sections walked in order per Step 4.5).
+
+### 2. Home Search — in-scope + `delivery: idx` → styled embed shell
+
+`home-search` is `inScope: true`, `delivery: idx`, `provider: "Showcase IDX"`. Per
+rule 2, this is NOT a normal section build. It dispatches:
+
+```
+/wp-page embed home-search --provider "Showcase IDX"
+```
+
+(matches `commands/wp-yolo.md` Step 4.6's inner-page IDX/plugin branch, and the
+home-page equivalent in Step 4.5 when the home page itself is IDX-delivered).
+
+### 3. Contact — in-scope + NO demo HTML → Review: needs demo
+
+`contact` is `inScope: true`, `delivery: theme`, `approved: true`, but no
+`demo/contact.html` exists. Per rule 3: do NOT build. Add to Review:
+
+> "Contact: approved/designed but no HTML — needs demo."
+
+### 4. services.html — demo page NOT in scope → skip
+
+`demo/services.html` has no matching entry (by slug/name) in `pages[]`. Per rule 4:
+skip it, add to Review:
+
+> "services: in demo but out of scope — skipped."
+
+## Summary of outcomes fired
+
+| Outcome                                   | Page          | Fired |
+|--------------------------------------------|---------------|-------|
+| theme → normal build                       | Home          | Yes   |
+| idx → `/wp-page embed <slug> --provider …` | Home Search   | Yes   |
+| in-scope, no HTML → Review "needs demo"    | Contact       | Yes   |
+| demo page not in scope → skip              | services      | Yes   |
+
+All four `commands/wp-yolo.md` Step 2.5 reconciliation outcomes are exercised by this
+fixture + assumed demo folder.

--- a/tests/fixtures/docs-sample/EXPECTED-SCOPE-MANIFEST.json
+++ b/tests/fixtures/docs-sample/EXPECTED-SCOPE-MANIFEST.json
@@ -1,0 +1,57 @@
+{
+  "source": "tests/fixtures/docs-sample",
+  "pages": [
+    {
+      "name": "Home",
+      "slug": "home",
+      "inScope": true,
+      "designProvided": true,
+      "delivery": "theme",
+      "approved": true
+    },
+    {
+      "name": "Home Search",
+      "slug": "home-search",
+      "inScope": true,
+      "designProvided": false,
+      "delivery": "idx",
+      "provider": "Showcase IDX",
+      "approved": true,
+      "notes": "native IDX widget, no custom mockup needed"
+    },
+    {
+      "name": "Contact",
+      "slug": "contact",
+      "inScope": true,
+      "designProvided": true,
+      "delivery": "theme",
+      "approved": true
+    },
+    {
+      "name": "About",
+      "slug": "about",
+      "inScope": true,
+      "designProvided": false,
+      "delivery": "theme",
+      "approved": false,
+      "notes": "no mockup on file; approval pending"
+    }
+  ],
+  "integrations": [
+    {
+      "name": "Showcase IDX",
+      "type": "idx",
+      "provider": "Showcase IDX",
+      "notes": "home search — native functionality, styled to design within platform limits"
+    }
+  ],
+  "constraints": {
+    "forms": "email-notification only, no CRM integration",
+    "seo": "on-page structure + XML sitemap",
+    "hosting": "client-hosted production; staging by us; one deploy at launch",
+    "responsive": "tablet/mobile interpreted from desktop — no mobile designs provided"
+  },
+  "review": [
+    "About page has no design provided and is not marked approved — treated as in-scope but unbuilt-ready pending client approval."
+  ]
+}

--- a/tests/fixtures/docs-sample/estimate.md
+++ b/tests/fixtures/docs-sample/estimate.md
@@ -1,0 +1,29 @@
+# Project Estimate — Docs Sample (fixture)
+
+## Scope Summary (confirmed)
+
+Client-hosted 5-page marketing site with an IDX-powered home search page. Design
+provided for Home and Contact; Home Search is a native IDX widget styled to the
+design system (no custom mockup needed — provider handles layout). About page has
+no mockup on file.
+
+## Pages in scope / Design provided
+
+| Page              | In scope | Design provided | Delivery | Approved |
+|-------------------|----------|------------------|----------|----------|
+| Home              | Yes      | Yes              | Theme    | Yes      |
+| Home Search (IDX) | Yes      | No (native)      | IDX      | Yes      |
+| Contact           | Yes      | Yes              | Theme    | Yes      |
+| About             | Yes      | No               | Theme    | No       |
+
+## Constraints
+
+- **Forms:** email-notification only, no CRM integration.
+- **SEO:** on-page structure + XML sitemap.
+- **Hosting:** client-hosted production; we host staging; one deploy at launch.
+- **Responsive:** tablet/mobile interpreted from desktop — no mobile designs provided.
+
+## Integrations
+
+- **Showcase IDX** — home search, native functionality, styled to design within
+  platform limits.

--- a/tests/fixtures/docs-sample/links.txt
+++ b/tests/fixtures/docs-sample/links.txt
@@ -1,0 +1,2 @@
+Existing site: https://example-old-site.test/
+IDX portal: https://showcaseidx.example.com/portal/demo-client

--- a/tests/fixtures/docs-sample/scope.csv
+++ b/tests/fixtures/docs-sample/scope.csv
@@ -1,0 +1,5 @@
+Page,In scope,Design provided,Delivery,Approved
+Home,Yes,Yes,Theme,Yes
+Home Search,Yes,No,IDX,Yes
+Contact,Yes,Yes,Theme,Yes
+About,Yes,No,Theme,No


### PR DESCRIPTION
> **Stacked on #9** (`feat/wp-yolo`). Base is `feat/wp-yolo`, so this diff shows only the wp-context work. Merge #9 first, then this.

## Summary

Adds `/wp-context` — read a project's `docs/` folder (scope spreadsheets, design PDFs, estimate/scope markdown, emails) and turn it into project context that **drives the build**: a `## Project Constraints` section in `.claude/CLAUDE.md` and an actionable `docs/.scope-manifest.json`. `/wp-yolo` now reconciles that scope with the demo so IDX/plugin pages become styled shells and out-of-scope pages are skipped.

### New surface
- **`/wp-context [docs-path]`** + **`wp-context` agent** — multi-format extraction (`.md`/`.txt` direct, `.pdf` via Read/`pdftotext`, `.xlsx`/`.ods` via `libreoffice --convert-to csv`, images visual). Synthesizes across all docs into one page list; missing tools degrade to a `review[]` note, never fail. Writes both artifacts idempotently (marker-delimited CLAUDE.md block + overwritten manifest).
- **`embed` page type for `/wp-page`** — `/wp-page embed <slug> [--provider <name>]` builds a design-token-styled shell with a marked insertion point (`<!-- EMBED: <provider> ... -->`) for provider-delivered pages (IDX, booking). Targets `front-page.php` when the slug is the home page.
- **Auto-run from `/wp-init`** when a `docs/` folder exists (silent skip otherwise).
- **Scope-aware `/wp-yolo`** — Phase 1.5 loads the manifest and reconciles it against the demo. Scope governs what/how, demo fills content: `theme`+HTML → normal build; `idx`/`plugin` → embed shell; in-scope+no-HTML → "needs demo"; demo-not-in-scope → skip. Absent manifest → unchanged demo-governed behavior.

### Docs
README gains a full `/wp-context` how-to (what to put in `docs/`, the two outputs, and a table mapping each scope case to what `/wp-yolo` does), a command-reference row, and `embed` in the `/wp-page` types. CHANGELOG `[Unreleased]` updated.

### Verification
Markdown command/agent specs (no runtime code). 5 new grep structural checks under `tests/checks/` (all pass, plus the 4 existing wp-yolo checks — no regression) + a hand-traced `tests/fixtures/docs-sample/` oracle (scope manifest + reconciliation trace validated against the real command bodies).

### Review trail
Built task-by-task with per-task spec+quality reviews. A whole-branch review caught 2 Important cross-file contract gaps (embed arg parsing; home-embed targeting `page-home.php` instead of `front-page.php`) + 1 Minor (reconcile-rule precedence) — all fixed and re-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
