### PR TITLE
feat(wp-normalize): fast-path already-delimited demos

### DIFF
--- a/agents/wp-normalize.md
+++ b/agents/wp-normalize.md
@@ -23,9 +23,10 @@ Work through these steps, in order, for the demo folder you are given:
 2. **Parse each page's DOM** → identify:
    - **Header** (detect whether it is shared across pages → build once if so).
    - **Footer** (shared → build once).
-   - **Body sections** — split by explicit `<section>` elements first; else fall back to
-     heuristic segmentation (major headings / block boundaries / background changes).
-     Name each section from its `id`/`class`/heading text.
+   - **Body sections** — if the page already carries the canonical `SECTION:` delimiters
+     (see Fast path below), trust them verbatim; else split by explicit `<section>`
+     elements; else fall back to heuristic segmentation (major headings / block boundaries
+     / background changes). Name each section from its delimiter, `id`/`class`, or heading.
 3. **Resolve CSS** — match external stylesheet rules to each section (by selector) so
    each section carries its own styles for the `wp-css` agent; extract global design
    tokens (colors / fonts / spacing).
@@ -39,6 +40,8 @@ Work through these steps, in order, for the demo folder you are given:
      CSS** — the exact canonical format the existing builders consume (so `/wp-section`,
      `/wp-header`, etc. still work for later fixups). Consolidate every matched external
      CSS rule for a section inline, into that emitted page, so each page is self-contained.
+     If the input page was **already delimited** (Fast path), keep its delimiters and
+     section markup as-is — your job on it is CSS consolidation + manifest, not re-marking.
    - `demo/.yolo-manifest.json` — orchestration source of truth: pages → sections →
      field-guesses → assets → shared-flags → contentTypes + links. Also the checkpoint
      report.
@@ -53,6 +56,26 @@ Use this exact delimiter pair around every section you split out, matching
 ...section markup...
 <!-- ============ END SECTION: <Name> ============ -->
 ```
+
+### Fast path — input already in canonical delimited form
+
+Some demos arrive **already delimited** in the exact format above — e.g. the output of
+figma-html-loop's `/demo-merge`, or a prior normalize run. Before segmenting a page, check
+for the `<!-- ============ SECTION: <Name> ============ -->` markers (and `SECTION: Header`
+/ `SECTION: Footer` around the shared blocks). When a page has them:
+
+- **Trust the delimiters as the section boundaries and names.** Do NOT re-segment the DOM,
+  re-decide where sections start/end, or rewrite the page to move/re-insert delimiters —
+  keep the markup byte-for-byte where you can. This skips the slowest, least-deterministic
+  part of Phase 1 (segmentation + per-file comment insertion).
+- **Still do everything else:** classify each delimited section (kind / CPT / contact /
+  fields), resolve + consolidate its CSS, extract content, and emit the manifest.
+- Because boundaries were **given, not guessed**, do NOT add `review[]` entries for
+  "heuristic segmentation" on these pages — that non-determinism doesn't apply here.
+
+Only fall back to `<section>`-splitting or heuristic segmentation for pages that LACK the
+delimiters. A page is "already delimited" only if the markers are the canonical pair above;
+ignore stray/non-matching comments.
 
 ## Classifier Rubric (CPT vs. static repeater)
 


### PR DESCRIPTION
## What

Adds a fast path to the `wp-normalize` agent: when an incoming demo page already carries the canonical `<!-- ============ SECTION: X ============ -->` delimiters, trust them as section boundaries and names instead of re-segmenting the DOM and re-inserting comments.

## Why

`/wp-yolo` was spending significant time having `wp-normalize` rewrite every demo page to insert section delimiters — the slowest, least-deterministic part of Phase 1 (and the source of most `review[]` segmentation entries). figma-html-loop's `/demo-merge` now emits pages **pre-delimited** in this exact canonical format, so that work is redundant on those inputs.

## Change

- **Step 2** checks for the canonical delimiters before falling back to `<section>`-splitting / heuristic segmentation.
- New **Fast path** subsection: trust given boundaries, keep markup byte-for-byte, still classify + consolidate CSS + emit the manifest, and do NOT log heuristic-segmentation `review[]` entries (boundaries were given, not guessed).
- **Step 6** preserves existing delimiters instead of re-marking.

Classification, CSS consolidation, and the manifest schema are unchanged — only the segmentation/comment-insertion work is skipped when the input is already canonical. Pages that arrive undelimited still take the full path.

## Testing

`tests/checks/wp-normalize.sh` → PASS.

Pairs with figma-html-loop PR #1 (demo-merge emits these delimiters).