### PR TITLE
fix: tailwind starter — body_classes fatal, typography pin, Spanish-tab gating

### DIFF
--- a/starter-theme/__tailwind__/fields/settings.php
+++ b/starter-theme/__tailwind__/fields/settings.php
@@ -2,7 +2,9 @@
 /**
  * ACF Field Group: Site Settings (Options Page)
  *
- * Tab structure: General | Header | Footer | Contact | Address | Social | Legal | Designer | Spanish Translations
+ * Tab structure: General | Header | Footer | Contact | Address | Social | Legal | Designer
+ * The Spanish Translations tab and all *_es fields are registered only when 'es' is in
+ * __STARTER___SUPPORTED_LANGS (English-only projects never see them).
  * The /wp-header and /wp-footer commands add project-specific fields to the Header and Footer tabs.
  *
  * @package __STARTER_NAME__
@@ -16,7 +18,7 @@ if (!function_exists('acf_add_local_field_group')) {
     return;
 }
 
-acf_add_local_field_group(array(
+$settings_group = array(
     'key' => 'group_settings',
     'title' => '__STARTER_NAME__ Settings',
     'fields' => array(
@@ -264,7 +266,28 @@ acf_add_local_field_group(array(
             'name' => 'designer_url',
             'type' => 'url',
         ),
+    ),
+    'location' => array(
+        array(
+            array(
+                'param' => 'options_page',
+                'operator' => '==',
+                'value' => '__starter__-settings',
+            ),
+        ),
+    ),
+    'menu_order' => 0,
+    'position' => 'normal',
+    'style' => 'default',
+    'label_placement' => 'top',
+    'instruction_placement' => 'label',
+    'active' => true,
+);
 
+
+// Register the Spanish Translations tab only when Spanish is a supported language.
+if ( in_array( 'es', __STARTER___SUPPORTED_LANGS, true ) ) {
+    $settings_group['fields'] = array_merge( $settings_group['fields'], array(
         // ── Spanish Translations Tab ─────────────────────────────
         array(
             'key' => 'field_settings_tab_spanish',
@@ -423,20 +446,7 @@ acf_add_local_field_group(array(
             'type' => 'url',
             'instructions' => 'Leave empty to use English version.',
         ),
-    ),
-    'location' => array(
-        array(
-            array(
-                'param' => 'options_page',
-                'operator' => '==',
-                'value' => '__starter__-settings',
-            ),
-        ),
-    ),
-    'menu_order' => 0,
-    'position' => 'normal',
-    'style' => 'default',
-    'label_placement' => 'top',
-    'instruction_placement' => 'label',
-    'active' => true,
-));
+    ) );
+}
+
+acf_add_local_field_group( $settings_group );

--- a/starter-theme/__tailwind__/inc/template-functions.php
+++ b/starter-theme/__tailwind__/inc/template-functions.php
@@ -24,6 +24,23 @@ function __starter___body_classes( $classes ) {
 		$classes[] = 'no-sidebar';
 	}
 
+	// Language class.
+	if ( function_exists( '__starter___get_current_lang' ) ) {
+		$classes[] = 'lang-' . __starter___get_current_lang();
+	}
+
+	// Page template class.
+	if ( is_page_template() ) {
+		$template       = get_page_template_slug();
+		$template_class = str_replace( array( '.php', '/' ), array( '', '-' ), $template );
+		$classes[]      = 'template-' . $template_class;
+	}
+
+	// Front page class.
+	if ( is_front_page() ) {
+		$classes[] = 'home-page';
+	}
+
 	return $classes;
 }
 add_filter( 'body_class', '__starter___body_classes' );

--- a/starter-theme/__tailwind__/inc/theme-setup.php
+++ b/starter-theme/__tailwind__/inc/theme-setup.php
@@ -94,26 +94,5 @@ function __starter___allow_svg_upload($mimes) {
 }
 add_filter('upload_mimes', '__starter___allow_svg_upload');
 
-/**
- * Add custom body classes
- */
-function __starter___body_classes($classes) {
-    // Add language class
-    if (function_exists('__starter___get_current_lang')) {
-        $classes[] = 'lang-' . __starter___get_current_lang();
-    }
-
-    // Add page template class
-    if (is_page_template()) {
-        $template = get_page_template_slug();
-        $template_class = str_replace(array('.php', '/'), array('', '-'), $template);
-        $classes[] = 'template-' . $template_class;
-    }
-
-    if (is_front_page()) {
-        $classes[] = 'home-page';
-    }
-
-    return $classes;
-}
-add_filter('body_class', '__starter___body_classes');
+// Body classes (lang / template / front-page) are added by __starter___body_classes()
+// in inc/template-functions.php — kept in one place to avoid a duplicate-declaration fatal.

--- a/starter-theme/__tailwind__/package.json
+++ b/starter-theme/__tailwind__/package.json
@@ -15,7 +15,7 @@
   "devDependencies": {
     "@wordpress/scripts": "^31.7.0",
     "@tailwindcss/cli": "^4.1.5",
-    "@tailwindcss/typography": "^0.6.0",
+    "@tailwindcss/typography": "^0.5.16",
     "tailwindcss": "^4.1.5",
     "browser-sync": "^3.0.4",
     "npm-run-all": "^4.1.5"

--- a/tests/checks/tailwind-starter.sh
+++ b/tests/checks/tailwind-starter.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Guards against two bugs that shipped in the __tailwind__ starter:
+#   1. a duplicate function declaration (fatal "Cannot redeclare")
+#   2. a nonexistent @tailwindcss/typography pin (0.6.x does not exist; it is a 0.5.x package)
+set -euo pipefail
+dir=starter-theme/__tailwind__
+
+# 1. No PHP function name declared more than once across the theme's inc/ + root PHP.
+# Match `function name(` anywhere (a space after `function` excludes `function_exists`).
+dupes=$(grep -rhoE 'function[[:space:]]+[a-zA-Z0-9_]+[[:space:]]*\(' "$dir" --include='*.php' \
+  | sed -E 's/.*function[[:space:]]+([a-zA-Z0-9_]+).*/\1/' | sort | uniq -d || true)
+if [ -n "$dupes" ]; then
+  echo "FAIL: duplicate PHP function declaration(s) in $dir: $dupes"; exit 1
+fi
+
+# 2. The typography dependency must be a real 0.5.x pin, never 0.6.x.
+if grep -Eq '"@tailwindcss/typography":\s*"\^?0\.6' "$dir/package.json"; then
+  echo "FAIL: @tailwindcss/typography pinned to nonexistent 0.6.x"; exit 1
+fi
+grep -Eq '"@tailwindcss/typography":\s*"\^?0\.5\.' "$dir/package.json" \
+  || { echo "FAIL: @tailwindcss/typography 0.5.x pin missing"; exit 1; }
+
+echo PASS

--- a/tests/checks/tailwind-starter.sh
+++ b/tests/checks/tailwind-starter.sh
@@ -20,4 +20,13 @@ fi
 grep -Eq '"@tailwindcss/typography":\s*"\^?0\.5\.' "$dir/package.json" \
   || { echo "FAIL: @tailwindcss/typography 0.5.x pin missing"; exit 1; }
 
+# 3. The settings page must gate the Spanish tab on language, not register it unconditionally.
+sf="$dir/fields/settings.php"
+grep -Fq "in_array( 'es', __STARTER___SUPPORTED_LANGS" "$sf" \
+  || { echo "FAIL: settings.php does not language-gate the Spanish Translations tab"; exit 1; }
+# Guard against the bareword regression (unquoted array keys / string) from a quoting bug.
+if grep -Eq 'settings_group\[fields\]|in_array\( es,' "$sf"; then
+  echo "FAIL: settings.php has unquoted bareword array key / string (quoting regression)"; exit 1
+fi
+
 echo PASS


### PR DESCRIPTION
## Summary

Fixes two fatal bugs in the shipped `__tailwind__` starter that broke fresh scaffolds, plus a language-leak in the settings page.

### Fixed
- **Duplicate `body_classes()` fatal.** `inc/theme-setup.php` and `inc/template-functions.php` each declared `__starter___body_classes()` with different logic and its own `body_class` filter → `Cannot redeclare` fatal on theme load. Merged the lang/template/front-page classes into the canonical `template-functions.php` copy (no behavior lost) and removed the duplicate.
- **Nonexistent typography pin.** `package.json` pinned `@tailwindcss/typography@^0.6.0`, which does not exist (it is a `0.5.x` package). Pinned `^0.5.16`.
- **Spanish Translations tab leaked on English-only sites.** `fields/settings.php` unconditionally registered a "Spanish Translations" tab + 18 `*_es` fields. Now the group is built in `$settings_group` and the Spanish block is `array_merge`'d in only when `es` is in `__STARTER___SUPPORTED_LANGS`. Verified at runtime: `langs=en` → tab hidden, 0 `_es` fields; `langs=en,es` → tab shown, 18 `_es` fields.

### Guard
`tests/checks/tailwind-starter.sh` fails on any duplicate PHP function declaration in the starter, a non-`0.5.x` typography pin, or an unscoped Spanish tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
