### PR TITLE
feat(wp-yolo): demo-parity fidelity gate + release 1.7.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "WordPress site-building methodology: demo HTML, custom themes with ACF/SCF, bilingual support, section-by-section generation",
-    "version": "1.6.0"
+    "version": "1.7.0"
   },
   "plugins": [
     {
@@ -16,7 +16,7 @@
         "repo": "yojahny55/claude-wp-builder"
       },
       "description": "Claude Code plugin for building custom WordPress sites — demo-first workflow with ACF/SCF fields, bilingual support, CF7 contact forms, and section-by-section theme generation",
-      "version": "1.6.0",
+      "version": "1.7.0",
       "author": {
         "name": "Yojahny"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-wp-builder",
   "description": "WordPress site-building methodology: demo HTML → custom theme with ACF/SCF, bilingual support, section-by-section building",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "author": {
     "name": "Yojahny"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [Unreleased]
 
+### Changed
+- **`/wp-yolo` now transcribes the demo instead of re-authoring it.** The `wp-css` agent gained a Transcription Mode (yolo path): it copies the demo's exact declared values (colors, heights, gaps, backgrounds), captures CSS `background:url()` + `@font-face` (not just `<img>`/`<link>`), and never adds "best-practice" edits that change measured geometry — fidelity over idiom. `wp-normalize` captures the full CSS surface, tags asset roles (logo / nav-graphic / hero / content), and assigns unique BEM blocks up front so parallel agents cannot collide on generic class names.
+
+### Added
+- **Demo-parity verification gate in `/wp-finalize`, auto-run by `/wp-yolo`.** Three layers — static (undefined `var(--x)`, CSS class collisions, font parity, background-image presence, nav-contract match), WP-CLI (`site_logo` / `inner_hero_image` seeded, menus, pages), and measured visual parity via the claude-in-chrome extension (`getComputedStyle` deltas vs the demo; hard deltas block, sub-pixel/antialiasing warn; skipped gracefully when the extension/site is unavailable). Critical findings auto-fix mechanically then re-verify; anything ambiguous blocks — `/wp-yolo` (including `--yolo`) will not report success while a divergence remains.
+- **Self-hosted font carry-over, role-based asset seeding, and a shared nav-class contract** (walker + header CSS agree, incl. dropdown-toggle baseline alignment).
+
 ## [1.6.0] - 2026-07-10
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -182,6 +182,14 @@ Build sections one at a time:
 /wp-yolo /path/to/demo-folder
 ```
 
+`/wp-yolo` **transcribes** the demo rather than re-deriving it — copying its exact colors,
+heights, gaps, CSS backgrounds, and self-hosted fonts verbatim (no "best-practice" edits that
+drift from the design) — and assigns each section a unique CSS block so parallel builds can't
+collide. Before it reports done it runs a **demo-parity gate** (static + WP-CLI + measured
+visual diff via the claude-in-chrome extension), auto-fixes mechanical divergences, and
+**blocks** on anything it can't safely fix — so a broken build fails loudly instead of shipping
+silently.
+
 Each command generates three files in parallel:
 - `fields/<section>.php` — ACF field definitions with bilingual support
 - `template-parts/section-<name>.php` — PHP template consuming those fields

--- a/agents/wp-css.md
+++ b/agents/wp-css.md
@@ -469,3 +469,22 @@ Enqueue page-specific styles conditionally in `functions.php`.
 10. **Follow the demo's visual design exactly** — match colors, spacing, layout from the reference
 11. **Each section gets its own commented block** — keep CSS organized and scannable
 12. **Use logical grouping** — within each section block, order properties: layout, box model, typography, visual, misc
+
+## Transcription Mode (when dispatched by /wp-yolo)
+
+When the dispatch says **"transcribe"** and hands you the demo's exact CSS for this section,
+the demo is the SOURCE OF TRUTH, not inspiration. Your job is to COPY, not re-author.
+
+- Copy the demo's **exact declared values** for `color`, `background`/`background-image`,
+  `width`/`height`/`min-height`/`max-height`, `padding`/`margin`/`gap`, `font-size`,
+  `line-height`, `border`, `border-radius`, `box-shadow`, and flex/grid track sizes.
+- **Capture CSS-declared assets:** `background:url(...)` and `@font-face` `src` — not just
+  `<img>`/`<link>`. Anything in CSS that a markup-only pass would miss, you carry.
+- **Do NOT "improve":** do not add a `min-height:44px` touch target, do not resize inputs or
+  textareas, do not round or clean up values, do not swap a literal for a near-token. Each
+  "reasonable best practice" changes the demo's measured geometry and is a bug here.
+- **Tokenize only on an exact match:** use a token only if its defined value equals the demo's
+  literal byte-for-byte; otherwise keep the literal.
+- **Scope everything under the assigned `block`** given in the dispatch (never a bare generic
+  name). Shared components use the shared class; per-page tweaks are scoped under the block.
+- (Still applies: never emit an undefined `var(--x)`.)

--- a/agents/wp-css.md
+++ b/agents/wp-css.md
@@ -29,7 +29,7 @@ resolve to a definition, or the page renders with the browser's unstyled fallbac
 
 ## CSS Custom Properties (Design Tokens)
 
-All design values MUST reference custom properties. Never hardcode raw values.
+All design values MUST reference custom properties. Never hardcode raw values. (Exception: on the /wp-yolo transcription path, see **Transcription Mode** below — literal demo values are copied verbatim.)
 
 ```css
 /* CORRECT */
@@ -235,7 +235,7 @@ For background images:
 
 ## Touch Targets
 
-All interactive elements MUST have a minimum touch target of 44px:
+All interactive elements MUST have a minimum touch target of 44px: (Exception: Transcription Mode / the /wp-yolo path does NOT add touch-target min-heights, to preserve the demo's exact geometry.)
 
 ```css
 .nav__link {
@@ -471,6 +471,8 @@ Enqueue page-specific styles conditionally in `functions.php`.
 12. **Use logical grouping** — within each section block, order properties: layout, box model, typography, visual, misc
 
 ## Transcription Mode (when dispatched by /wp-yolo)
+
+**On the transcription (yolo) path, this section OVERRIDES the 'All design values MUST reference custom properties' rule and the Touch Targets 44px rule above** — keep the demo's literal values and exact geometry; do not tokenize non-matching values and do not add touch-target min-heights.
 
 When the dispatch says **"transcribe"** and hands you the demo's exact CSS for this section,
 the demo is the SOURCE OF TRUTH, not inspiration. Your job is to COPY, not re-author.

--- a/agents/wp-css.md
+++ b/agents/wp-css.md
@@ -233,6 +233,10 @@ For background images:
 }
 ```
 
+## Nav Styling
+
+Nav markup/styles MUST follow the nav-class contract in the wp-theme-standards skill.
+
 ## Touch Targets
 
 All interactive elements MUST have a minimum touch target of 44px: (Exception: Transcription Mode / the /wp-yolo path does NOT add touch-target min-heights, to preserve the demo's exact geometry.)

--- a/agents/wp-css.md
+++ b/agents/wp-css.md
@@ -17,6 +17,16 @@ Before generating ANY CSS, read the project's existing `assets/css/styles.css` f
 
 Use ONLY the project's existing design tokens. Never hardcode colors, spacing, or font sizes.
 
+**Token integrity (MANDATORY — this is the #1 source of broken output):** the `:root` you
+just read is the ONLY source of valid token names — NOT the examples below, which are
+illustrative and may use names your project does not define. Before you write any
+`var(--x)`, confirm `--x` is defined in that `:root`. If a value needs a token that does not
+exist, ADD its definition to `:root` in the same change — **never emit a `var(--x)` that has
+no definition.** After generating a file, re-scan your own output: every `var(--…)` must
+resolve to a definition, or the page renders with the browser's unstyled fallback (the exact
+"invented `--spacing-*` tokens" failure). Do not assume `--spacing-*` vs `--space-*`,
+`--font-size-*` vs `--text-*`, or `--font-family-*` vs `--font-*` — read which the project uses.
+
 ## CSS Custom Properties (Design Tokens)
 
 All design values MUST reference custom properties. Never hardcode raw values.
@@ -25,9 +35,9 @@ All design values MUST reference custom properties. Never hardcode raw values.
 /* CORRECT */
 .hero__title {
     color: var(--color-primary);
-    font-size: var(--text-4xl);
+    font-size: var(--font-size-4xl);
     margin-bottom: var(--spacing-md);
-    font-family: var(--font-heading);
+    font-family: var(--font-family-primary);
 }
 
 /* WRONG — never do this */
@@ -40,10 +50,10 @@ All design values MUST reference custom properties. Never hardcode raw values.
 ```
 
 Common token categories to expect:
-- Colors: `--color-primary`, `--color-secondary`, `--color-accent`, `--color-text`, `--color-bg`, etc.
+- Colors: `--color-primary`, `--color-secondary`, `--color-accent`, `--color-text`, `--color-background`, etc.
 - Spacing: `--spacing-xs`, `--spacing-sm`, `--spacing-md`, `--spacing-lg`, `--spacing-xl`, `--spacing-2xl`
-- Typography: `--text-sm`, `--text-base`, `--text-lg`, `--text-xl`, `--text-2xl`, `--text-3xl`, `--text-4xl`
-- Fonts: `--font-body`, `--font-heading`
+- Typography: `--font-size-sm`, `--font-size-base`, `--font-size-lg`, `--font-size-xl`, `--font-size-2xl`, `--font-size-3xl`, `--font-size-4xl`
+- Fonts: `--font-family-secondary`, `--font-family-primary`
 - Borders: `--radius-sm`, `--radius-md`, `--radius-lg`
 - Shadows: `--shadow-sm`, `--shadow-md`, `--shadow-lg`
 
@@ -128,18 +138,18 @@ Every section MUST be wrapped in a clear comment delimiter:
 
 .hero {
     padding: var(--spacing-2xl) 0;
-    background-color: var(--color-bg);
+    background-color: var(--color-background);
 }
 
 .hero__title {
     font-size: clamp(1.75rem, 4vw, 3.5rem);
-    font-family: var(--font-heading);
+    font-family: var(--font-family-primary);
     color: var(--color-primary);
     line-height: 1.2;
 }
 
 .hero__description {
-    font-size: var(--text-lg);
+    font-size: var(--font-size-lg);
     color: var(--color-text);
     max-width: 60ch;
     margin-bottom: var(--spacing-lg);
@@ -355,7 +365,7 @@ Enqueue page-specific styles conditionally in `functions.php`.
 
 .values {
     padding: var(--spacing-2xl) 0;
-    background-color: var(--color-bg-alt);
+    background-color: var(--color-background-alt);
 }
 
 .values__header {
@@ -365,7 +375,7 @@ Enqueue page-specific styles conditionally in `functions.php`.
 
 .values__label {
     display: inline-block;
-    font-size: var(--text-sm);
+    font-size: var(--font-size-sm);
     color: var(--color-accent);
     text-transform: uppercase;
     letter-spacing: 0.1em;
@@ -375,7 +385,7 @@ Enqueue page-specific styles conditionally in `functions.php`.
 
 .values__title {
     font-size: clamp(1.5rem, 3vw, 2.5rem);
-    font-family: var(--font-heading);
+    font-family: var(--font-family-primary);
     color: var(--color-primary);
 }
 
@@ -405,15 +415,15 @@ Enqueue page-specific styles conditionally in `functions.php`.
 }
 
 .values__card-title {
-    font-size: var(--text-lg);
+    font-size: var(--font-size-lg);
     font-weight: 600;
     color: var(--color-primary);
     margin-bottom: var(--spacing-xs);
 }
 
 .values__card-description {
-    font-size: var(--text-base);
-    color: var(--color-text-muted);
+    font-size: var(--font-size-base);
+    color: var(--color-text-light);
     line-height: 1.6;
 }
 
@@ -448,6 +458,7 @@ Enqueue page-specific styles conditionally in `functions.php`.
 
 1. **No build tools, no frameworks** — vanilla CSS only
 2. **Never hardcode colors, spacing, or font sizes** — use CSS custom properties exclusively
+2b. **Never emit an undefined `var(--x)`** — every custom property you reference must be defined in the project's `:root`; if it isn't, add the definition there in the same change
 3. **BEM naming on every class** — `.block__element--modifier`
 4. **Mobile-first** — base styles for mobile, `min-width` queries for larger screens
 5. **Section delimiters** — every section wrapped in `/* ============ Section: Name ============ */`

--- a/agents/wp-normalize.md
+++ b/agents/wp-normalize.md
@@ -213,3 +213,162 @@ List **every** low-confidence decision (any classification you are not fully cer
 any inferred field, any structural guess made from heuristic segmentation rather than
 explicit `<section>` tags) as a plain-language entry in `review[]`. This list is read
 verbatim at the Phase 1 checkpoint.
+
+## Fidelity capture
+
+Beyond classification, the manifest must carry enough raw material that downstream
+`wp-css` agents **transcribe** rather than guess, and that parallel agents can never
+collide on a class name. Do this per section/page, in addition to everything above:
+
+1. **Verbatim CSS.** For every section, collect the exact declared CSS rules that match
+   it (by selector, following the same resolution used in Analysis Procedure step 3) and
+   record them verbatim into `section.cssRules` — a raw CSS string, not a paraphrase.
+   `wp-css` transcribes this string; it must not need to reinvent values.
+2. **Backgrounds.** Scan each section's resolved CSS for `background` / `background-image:
+   url(...)` and record every referenced image path into `section.backgrounds[]`.
+3. **Fonts.** Scan the stylesheet(s) for `@font-face` blocks and record each into
+   `section.fonts[]` as `{ family, weight, style, src: [ "<woff2 path>", ... ] }` (prefer
+   the `woff2` entry in the `src` list; keep multiple sources if declared).
+4. **Computed dimensions.** When a section (or a key element inside it) has a fixed
+   `height` and/or `width` declared in CSS (not `auto`, not percentage-fluid), record it
+   into `section.computed` as `{ height?, width? }`. Omit keys that aren't fixed.
+5. **Unique block names.** Assign `section.block` yourself — you do not wait for
+   downstream agents to request a name. The rule: `<page-slug>-<section-name>`
+   (kebab-case), e.g. `sp-services` for the `services` section on `services.html`. Home
+   (`index`) sections may drop the page prefix and use the bare section name **only if**
+   that bare name is not also used as a block on any other page — if two pages both have
+   a `services`-shaped section, home's becomes `home-services` and the inner page's
+   `sp-services`; there is no bare `.services` in the manifest. This is what makes
+   parallel `wp-css` runs collision-proof: every block is unique before any builder agent
+   starts.
+6. **Asset roles.** Every image referenced anywhere in the demo (header, nav, sections,
+   footer) gets one entry in the top-level `assets[]` array: `{ file, role, page?, field?
+   }`, where `role` is one of:
+   - `logo` — the site identity mark, normally in the header/footer, linked to home.
+   - `nav-graphic` — an image used as a navigation element (e.g. a menu icon, a nav-bar
+     decorative graphic) — **never** classified as `logo` even if it sits beside the logo
+     in the header. Distinguish by function: does it link home and represent the brand
+     (`logo`), or does it toggle/decorate the nav (`nav-graphic`)?
+   - `hero` — an image set via CSS `background:url()` on a hero/banner section (also
+     already captured in that section's `backgrounds[]`; the top-level `assets[]` entry
+     additionally tags its role and originating page/field for the seeding pipeline).
+   - `content` — any other in-content image (card photo, inline `<img>`, etc.).
+7. **Shared components.** When the same card/accordion/list structure (same markup
+   shape + same class naming) recurs on 2+ pages, do not let each page's build treat it
+   as a fresh component. Mark it as a **shared component**: add a `sharedComponents[]`
+   top-level array with `{ name, class, pages: [...], sections: [...] }`, using one
+   shared class for the base structure. Per-page visual differences still get scoped
+   overrides under that page's own `block` (e.g. `.home-services .card` background tweak)
+   rather than a second copy of the component.
+
+### Extended per-section schema
+
+```jsonc
+{
+  "name": "<string>",
+  "kind": "static" | "contact" | "cpt-teaser",
+  "block": "<string>",                 // unique BEM block, assigned here
+  "cssRules": "<string>",              // verbatim declared CSS for this section
+  "backgrounds": [ "<image-url>" ],    // from background:url() in cssRules
+  "fonts": [                            // from @font-face blocks touching this section
+    { "family": "<string>", "weight": "<string|number>", "style": "normal|italic",
+      "src": [ "<woff2-path>" ] }
+  ],
+  "computed": { "height": "<string>", "width": "<string>" }, // fixed dims only, both optional
+  "confidence": 0.0,
+  "rationale": "<string, optional>",
+  "fields": [ /* ACF field guesses */ ],
+  "assets": [ /* image paths referenced by this section */ ]
+}
+```
+
+Top-level additions:
+
+```jsonc
+{
+  "assets": [
+    { "file": "<path>", "role": "logo" | "nav-graphic" | "hero" | "content",
+      "page": "<slug, optional>", "field": "<string, optional>" }
+  ],
+  "sharedComponents": [
+    { "name": "<string>", "class": "<shared-css-class>",
+      "pages": [ "<slug>", "..." ], "sections": [ "<section-name>", "..." ] }
+  ]
+}
+```
+
+### Filled example — two pages, colliding section names resolved, hero background, font, nav-graphic
+
+```jsonc
+{
+  "source": "demo-source/agency-co",
+  "pages": [
+    {
+      "slug": "index", "role": "home", "file": "demo/index.html",
+      "sections": [
+        { "name": "hero", "kind": "static", "block": "home-hero",
+          "cssRules": ".hero{height:640px;background:url(images/hero-bg.jpg) center/cover no-repeat;}",
+          "backgrounds": [ "images/hero-bg.jpg" ],
+          "fonts": [], "computed": { "height": "640px" },
+          "fields": [
+            { "name": "hero_title", "type": "text" },
+            { "name": "hero_subtitle", "type": "textarea" }
+          ], "assets": [] },
+        { "name": "services", "kind": "static", "block": "home-services",
+          "cssRules": ".services{padding:80px 0;font-family:'Brand Sans',sans-serif;} .services .card{width:320px;}",
+          "backgrounds": [], "fonts": [], "computed": {},
+          "confidence": 1.0,
+          "rationale": "Same card structure also appears on services.html — see sharedComponents",
+          "fields": [ { "name": "services_heading", "type": "text" } ],
+          "assets": [] }
+      ]
+    },
+    {
+      "slug": "services", "role": "inner", "file": "demo/services.html",
+      "sections": [
+        { "name": "services", "kind": "static", "block": "sp-services",
+          "cssRules": ".services{padding:60px 0;} .services .card{width:320px;}",
+          "backgrounds": [], "fonts": [], "computed": {},
+          "confidence": 1.0,
+          "rationale": "Same card structure as index.html's services teaser — shared component, page-scoped padding override",
+          "fields": [ { "name": "services_intro", "type": "textarea" } ],
+          "assets": [] }
+      ]
+    }
+  ],
+  "shared": {
+    "header": true, "footer": true,
+    "headerDivergentPages": [], "footerDivergentPages": []
+  },
+  "assets": [
+    { "file": "images/logo.svg", "role": "logo", "page": "index", "field": "site_logo" },
+    { "file": "images/nav-menu-icon.svg", "role": "nav-graphic", "page": "index" },
+    { "file": "images/hero-bg.jpg", "role": "hero", "page": "index", "field": "hero_image" }
+  ],
+  "sharedComponents": [
+    { "name": "services-card", "class": ".services .card",
+      "pages": [ "index", "services" ], "sections": [ "services" ] }
+  ],
+  "contentTypes": [],
+  "review": [
+    "'services' section shape is identical on index and services.html — resolved to distinct blocks home-services / sp-services, shared component .services .card built once with per-page padding override",
+    "images/nav-menu-icon.svg sits next to images/logo.svg in the header but toggles the mobile nav — tagged nav-graphic, not logo"
+  ]
+}
+```
+
+Global font declaration example (site-wide, not tied to one section — record once at
+manifest top level under `"fonts"` if it applies globally, or per-section under
+`section.fonts` if scoped):
+
+```jsonc
+"fonts": [
+  { "family": "Brand Sans", "weight": "400", "style": "normal",
+    "src": [ "fonts/brand-sans-regular.woff2" ] }
+]
+```
+
+List every unresolved shared-component or asset-role ambiguity in `review[]` alongside
+the existing classification entries — the checkpoint reader treats them the same way.</new_string>
+</invoke>
+

--- a/agents/wp-normalize.md
+++ b/agents/wp-normalize.md
@@ -350,7 +350,7 @@ Top-level additions:
   "assets": [
     { "file": "images/logo.svg", "role": "logo", "page": "index", "field": "site_logo" },
     { "file": "images/nav-menu-icon.svg", "role": "nav-graphic", "page": "index" },
-    { "file": "images/hero-bg.jpg", "role": "hero", "page": "index", "field": "hero_image" }
+    { "file": "images/hero-bg.jpg", "role": "hero", "page": "index", "field": "inner_hero_image" }
   ],
   "sharedComponents": [
     { "name": "services-card", "class": ".services .card",
@@ -376,6 +376,4 @@ manifest top level under `"fonts"` if it applies globally, or per-section under
 ```
 
 List every unresolved shared-component or asset-role ambiguity in `review[]` alongside
-the existing classification entries — the checkpoint reader treats them the same way.</new_string>
-</invoke>
-
+the existing classification entries — the checkpoint reader treats them the same way.

--- a/agents/wp-normalize.md
+++ b/agents/wp-normalize.md
@@ -290,6 +290,11 @@ Top-level additions:
     { "file": "<path>", "role": "logo" | "nav-graphic" | "hero" | "content",
       "page": "<slug, optional>", "field": "<string, optional>" }
   ],
+```
+
+**Note:** this top-level `assets[]` (role-tagged objects) is distinct from the per-section `assets` field (plain image paths); the role-tagged top-level list is the source of truth for seeding.
+
+```jsonc
   "sharedComponents": [
     { "name": "<string>", "class": "<shared-css-class>",
       "pages": [ "<slug>", "..." ], "sections": [ "<section-name>", "..." ] }
@@ -316,7 +321,9 @@ Top-level additions:
           ], "assets": [] },
         { "name": "services", "kind": "static", "block": "home-services",
           "cssRules": ".services{padding:80px 0;font-family:'Brand Sans',sans-serif;} .services .card{width:320px;}",
-          "backgrounds": [], "fonts": [], "computed": {},
+          "backgrounds": [], "fonts": [
+            { "family": "Brand Sans", "weight": "400", "style": "normal", "src": [ "fonts/brand-sans-regular.woff2" ] }
+          ], "computed": {},
           "confidence": 1.0,
           "rationale": "Same card structure also appears on services.html — see sharedComponents",
           "fields": [ { "name": "services_heading", "type": "text" } ],

--- a/agents/wp-template.md
+++ b/agents/wp-template.md
@@ -201,10 +201,26 @@ When generating custom navigation markup, extend `Walker_Nav_Menu`:
 class Prefix_Nav_Walker extends Walker_Nav_Menu {
     public function start_el(&$output, $item, $depth = 0, $args = null, $id = 0) {
         $classes = implode(' ', $item->classes);
-        $output .= '<li class="nav__item ' . esc_attr($classes) . '">';
+        // Dropdown parents carry the contract's has-children modifier.
+        $has_children = in_array('menu-item-has-children', $item->classes, true);
+        $li_class = 'nav__item' . ($has_children ? ' nav__item--has-children' : '');
+        $output .= '<li class="' . esc_attr(trim($li_class . ' ' . $classes)) . '">';
         $output .= '<a class="nav__link" href="' . esc_url($item->url) . '">';
         $output .= esc_html($item->title);
         $output .= '</a>';
+        // Dropdown items emit a toggle control per the nav-class contract.
+        if ($has_children) {
+            $output .= '<button class="nav__toggle" aria-expanded="false" aria-label="' . esc_attr__('Toggle submenu', 'textdomain') . '"></button>';
+        }
+    }
+
+    // Child <ul> MUST use .nav__submenu to match the contract (default is 'sub-menu').
+    public function start_lvl(&$output, $depth = 0, $args = null) {
+        $output .= '<ul class="nav__submenu">';
+    }
+
+    public function end_lvl(&$output, $depth = 0, $args = null) {
+        $output .= '</ul>';
     }
 
     public function end_el(&$output, $item, $depth = 0, $args = null) {
@@ -220,10 +236,17 @@ wp_nav_menu(array(
     'theme_location' => 'primary',
     'container'      => 'nav',
     'container_class'=> 'nav',
-    'menu_class'     => 'nav__list',
+    'menu_class'     => 'nav__menu',
     'walker'         => new Prefix_Nav_Walker(),
 ));
 ```
+
+The walker output MUST match the nav-class contract exactly: `.nav__menu` on the top-level
+`<ul>`, `.nav__item` (+ `.nav__item--has-children` on dropdown parents) on each `<li>`,
+`.nav__link` on anchors, `.nav__submenu` on the child `<ul>`, and `.nav__toggle` on the
+dropdown control. A `menu_class` or submenu class that diverges from this leaves the header
+CSS targeting selectors the walker never emits (dead selectors — the Layer-1 nav-contract
+gate fails).
 
 ## Teaser Fidelity (CPT teaser / archive cards)
 

--- a/agents/wp-template.md
+++ b/agents/wp-template.md
@@ -193,6 +193,8 @@ For custom query pagination, use `paginate_links()`.
 
 ## Custom Nav Walker
 
+Nav markup/styles MUST follow the nav-class contract in the wp-theme-standards skill.
+
 When generating custom navigation markup, extend `Walker_Nav_Menu`:
 
 ```php

--- a/agents/wp-template.md
+++ b/agents/wp-template.md
@@ -225,6 +225,10 @@ wp_nav_menu(array(
 ));
 ```
 
+## Teaser Fidelity (CPT teaser / archive cards)
+
+CPT single-post teasers (used in archive/blog loops, e.g. `.blog__card` above) MUST transcribe the demo's own teaser layout for that content type — matching its markup structure, image treatment, and meta fields (date, category, author, etc.) exactly as shown in the demo HTML. Do not reuse a generic archive card template for a CPT that has its own teaser design in the demo. Only fall back to a generic card (like the `WP_Query` example above) when the demo has no dedicated teaser markup for that post type.
+
 ## Complete Section Template Example
 
 Here is a full example of a properly structured template part:

--- a/commands/wp-finalize.md
+++ b/commands/wp-finalize.md
@@ -205,11 +205,11 @@ Layer 2 runs when `.wp-create.json` exists and WordPress is reachable (reuse `$W
 1. **`site_logo` + critical options non-empty** — `critical`
 
    ```bash
-   $WP option get site_logo
+   $WP eval "echo get_field('site_logo','option') ? 'OK' : 'EMPTY';"
    $WP option get blogname
    $WP option get blogdescription
    ```
-   **PASS** if `site_logo` and every other critical site option return a non-empty value. **FAIL** listing which option is empty/unset.
+   The logo is stored as the ACF options field `options_site_logo` (seeded via `update_field('site_logo', $LOGO_ID, 'option')`), NOT the WordPress core `site_logo` option — read it with `get_field('site_logo','option')`, matching the `inner_hero_image` check below. **PASS** if `site_logo` and every other critical site option return a non-empty value. **FAIL** listing which option is empty/unset.
 
 2. **`inner_hero_image` seeded per in-scope page** — `critical`
 

--- a/commands/wp-finalize.md
+++ b/commands/wp-finalize.md
@@ -154,6 +154,50 @@ If `.wp-create.json` exists in the project, read `wp_cli.wrapper` and run runtim
 
 ---
 
+### Demo-parity gate — Layer 1 (static)
+
+Layer 1 of the 3-layer demo-parity gate (static / theme-file level). Runs against the theme's CSS, templates, and the manifest produced by `/wp-normalize` (`section.backgrounds`, `section.fonts`, `section.block`). Every check below is **critical** — a FAIL here blocks delivery.
+
+1. **Undefined `var(--x)` scan** — `critical`
+
+   Grep all theme CSS for `var(--` usages. For each custom property referenced, verify a matching definition exists in a `:root { }` block or `@theme { }` block (Tailwind starter). List any `var(--x)` used with no matching definition — these render as the property's fallback (or nothing) in the browser, silently breaking colors/spacing/fonts.
+
+   **PASS** if every `var(--x)` resolves. **FAIL** with file:line and the undefined property name.
+
+2. **CSS collision scan** — `critical`
+
+   Grep all section CSS files for class selectors. Flag two cases:
+   - The **same class block** (identical selector) defined in 2+ section files with **conflicting declarations** (different values for the same property).
+   - A **known-generic block** (e.g. `.services`, `.hero`, `.card`, `.acc`, `.accordion`) used **unscoped**, outside its assigned owner section, where it could bleed into other pages.
+
+   **IMPORTANT nuance:** a shared component class used under **different page-scoped parents** (e.g. `.sp-services .accordion` vs `.condos .accordion`) is **correct usage, not a collision** — the parent scope makes each rule apply only within its own section. The scan flags **unscoped** redefinition only (a bare `.accordion { }` with no page-scoped ancestor selector competing with another bare `.accordion { }`), never scoped-but-shared component classes.
+
+   **PASS** if no unscoped collisions found. **FAIL** listing the colliding selector, the files/lines involved, and whether it's a raw conflict or an unscoped-generic-block issue.
+
+3. **Font parity** — `critical`
+
+   For every `font-family` used in theme CSS: verify it is either (a) bundled — a matching `@font-face` declaration exists AND the referenced font file is present under `assets/fonts/`, or (b) an intentional system-font stack (e.g. `-apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif`) with no `@font-face` expected.
+
+   Then, in reverse: for every `@font-face` recorded in the manifest's `section.fonts` (captured from the demo by `/wp-normalize`), verify a carried counterpart `@font-face` exists in the theme CSS with the file present in `assets/fonts/`.
+
+   **PASS** if every used font resolves and every demo font was carried over. **FAIL** listing missing font files or demo fonts dropped during build.
+
+4. **Background-image presence** — `critical`
+
+   For every `background:url()` / `background-image:` entry recorded in the manifest's `section.backgrounds` (captured from the demo), verify it is present in the theme CSS as a transcribed `background:url()` rule, or seeded as an ACF image field on that section.
+
+   **PASS** if every demo background is accounted for. **FAIL** listing which section's background was dropped.
+
+5. **Nav-contract match** — `critical`
+
+   Read the header CSS (`.nav`, `.nav__menu`, `.nav__item`, etc. — see the nav-class contract in `skills/wp-theme-standards/SKILL.md`). For each class the header CSS targets, verify the class appears in the actual `wp_nav_menu()` walker output (check `inc/` for a custom `Walker_Nav_Menu` or the `wp_nav_menu` args' `menu_class`/`items_wrap`).
+
+   **PASS** if every CSS-targeted nav class exists in the walker output. **FAIL** listing CSS classes with no matching walker output (dead selectors — usually the sign the walker was never updated to match the CSS).
+
+**PASS** if all 5 static checks pass. **FAIL** listing every offending check with its details — do not stop at the first failure, collect all of them so the user gets one full punch list.
+
+---
+
 ## Step 4: Print Report
 
 ```

--- a/commands/wp-finalize.md
+++ b/commands/wp-finalize.md
@@ -198,6 +198,73 @@ Layer 1 of the 3-layer demo-parity gate (static / theme-file level). Runs agains
 
 ---
 
+### Demo-parity gate — Layer 2 (WP-CLI, when WordPress is reachable)
+
+Layer 2 runs when `.wp-create.json` exists and WordPress is reachable (reuse `$WP` from Check 7). Every check below is **critical**.
+
+1. **`site_logo` + critical options non-empty** — `critical`
+
+   ```bash
+   $WP option get site_logo
+   $WP option get blogname
+   $WP option get blogdescription
+   ```
+   **PASS** if `site_logo` and every other critical site option return a non-empty value. **FAIL** listing which option is empty/unset.
+
+2. **`inner_hero_image` seeded per in-scope page** — `critical`
+
+   For each in-scope page (from the manifest / scope file), find its post ID and check the ACF field:
+   ```bash
+   $WP post list --post_type=page --format=ids
+   $WP eval "echo get_field('inner_hero_image', <post_id>) ? 'OK' : 'EMPTY';"
+   ```
+   **PASS** if every in-scope page has `inner_hero_image` seeded. **FAIL** listing which pages are missing it.
+
+3. **Menus assigned to locations** — `critical`
+
+   ```bash
+   $WP menu location list --format=table
+   ```
+   **PASS** if every registered nav location (e.g. `primary_en`, `primary_es`, `footer_en`, `footer_es`) has a menu assigned. **FAIL** listing unassigned locations.
+
+4. **In-scope pages exist** — `critical`
+
+   ```bash
+   $WP post list --post_type=page --format=table
+   ```
+   **PASS** if every in-scope page from the manifest has a corresponding WordPress page. **FAIL** listing missing pages.
+
+**PASS** if all 4 checks pass. **FAIL** listing every offending check with its details. If WordPress is not reachable (no `.wp-create.json`, or `$WP` calls fail to connect), **SKIP** Layer 2 with a noted reason — this is not a failure, but Layers 1 and 3 still gate.
+
+---
+
+### Demo-parity gate — Layer 3 (measured visual parity, claude-in-chrome)
+
+Layer 3 is the backstop that measures **computed styles**, not just screenshots, so divergence is caught at build time instead of weeks later.
+
+1. **Detect claude-in-chrome availability.** Call the extension's tabs/context tool (e.g. `tabs_context_mcp`). If the claude-in-chrome MCP tools are unavailable, not connected, or the built site / demo URL is unreachable, **SKIP Layer 3 with a noted reason — this is NOT a failure.** Layers 1-2 still gate delivery on their own.
+
+2. **Load demo + built page.** For each in-scope page, navigate to the demo URL and to the corresponding built (local WordPress) URL.
+
+3. **Measure computed styles.** Via `javascript_tool`, run `getComputedStyle()` on matching selectors on both pages (hero, nav, section backgrounds, headings, buttons) and compare the results.
+
+4. **Classify every delta:**
+   - **Hard delta (BLOCK)** — critical:
+     - A `background-image` present in the demo is missing in the build.
+     - `color` / `background-color` resolves to a **different hex** between demo and build.
+     - A fixed `height` / `width` differs by **more than 3% or 8px** (whichever is larger).
+     - `font-family` resolves to a **system fallback stack** instead of the demo's actual font face.
+   - **Soft delta (WARN, non-blocking):**
+     - Sub-pixel geometry differences.
+     - Antialiasing / font-smoothing rendering variance.
+     - Any value within the 3%/8px threshold.
+
+5. **Confirm logo + hero rendering.** Verify the logo renders as an actual image (not a text fallback) and that hero section background images are visible (not blank/broken).
+
+**PASS** if no hard deltas found (soft deltas are reported but do not block). **FAIL** listing every hard delta (selector, property, demo value vs. built value). **SKIP** (not a failure) if claude-in-chrome or either URL is unavailable — state the reason (e.g. "claude-in-chrome not connected", "demo URL unreachable", "built site not running").
+
+---
+
 ## Step 4: Print Report
 
 ```

--- a/commands/wp-init.md
+++ b/commands/wp-init.md
@@ -362,6 +362,24 @@ cd <theme-dir> && npm install && npm run build
 ```
 This generates `assets/css/dist/main.css` and `assets/js/dist/index.js` needed for the theme to function.
 
+## Step 9.5: Initialize git repository
+
+The theme directory is the versioned deliverable and `/wp-yolo` requires a git repo
+(for a rollback baseline and worktree-based isolation). Initialize one if absent:
+
+```bash
+cd <theme-dir>
+git rev-parse --is-inside-work-tree >/dev/null 2>&1 || {
+  git init -q
+  printf 'node_modules/\n.DS_Store\n*.log\n' > .gitignore
+  # Tailwind build output is regenerable — ignore dist if this is the tailwind template
+  git add -A && git commit -q -m "chore: scaffold <slug> theme from starter"
+}
+```
+
+Idempotent: if `<theme-dir>` is already inside a git work tree (e.g. the whole
+site is versioned), skip init and leave the existing repo untouched.
+
 ## Step 10: Print Summary
 
 Print a summary:

--- a/commands/wp-page.md
+++ b/commands/wp-page.md
@@ -159,21 +159,26 @@ Dispatch **wp-css** agent:
 
 Dispatch **wp-template** agent:
 
-> Generate `404.php`:
+> Generate `404.php` — a fully styled theme template, NOT the starter/underscores
+> boilerplate. Overwrite any existing `404.php`. Match the site's visual design:
+> reuse the theme's buttons, typography, and spacing, and apply frontend-design
+> best practices so it reads as a converted theme page (header/footer supply the chrome).
 > - `get_header()`
 > - Centered error message section:
 >   - Large "404" display heading
 >   - Message: `prefix_get_field('404_message', 'option')` with fallback "Page not found"
 >   - Description: `prefix_get_field('404_description', 'option')` with fallback
 >   - Search form using `get_search_form()`
->   - "Back to Home" button linking to `home_url('/')`
+>   - "Back to Home" button linking to `home_url('/')`, styled with the theme's button class
 >   - Optional: recent posts or suggested pages
 > - `get_footer()`
-> - BEM classes: `.error-404__*`
+> - BEM classes: `.error-404__*`, matching the design tokens in the theme CSS
 
 Dispatch **wp-css** agent:
 
-> Add 404 page CSS to `assets/css/styles.css` within delimiters. Include: centered layout, large 404 text, search form styling, responsive design.
+> Add 404 page CSS to `assets/css/styles.css` within delimiters, using the project's
+> design-system custom properties (no new colors). Include: centered layout, large 404
+> text, search form styling, themed button, responsive design.
 
 ---
 
@@ -181,7 +186,9 @@ Dispatch **wp-css** agent:
 
 Dispatch **wp-template** agent:
 
-> Generate `search.php`:
+> Generate `search.php` — a fully styled theme template, NOT the starter/underscores
+> boilerplate. Overwrite any existing `search.php`. Reuse the site's card/list markup and
+> design tokens so results and the no-results state read as converted theme pages.
 > - `get_header()`
 > - Page title: `printf( esc_html__( 'Search results for: %s', '<slug>' ), '<span>' . get_search_query() . '</span>' )`
 > - `if ( have_posts() )` loop reusing the site's card/list markup via

--- a/commands/wp-section.md
+++ b/commands/wp-section.md
@@ -1,7 +1,7 @@
 ---
 description: One-shot section builder — generates ACF fields + template part + CSS for a section from the demo
 allowed-tools: Read, Write, Edit, Bash, Grep, Glob, Agent
-argument-hint: "<section-name> [screenshot-path] [--cf7] [--page <slug>] [--target <template>]"
+argument-hint: "<section-name> [screenshot-path] [--cf7] [--page <slug>] [--target <template>] [--transcribe] [--block <name>] [--css <source>]"
 ---
 
 # WP Section — One-Shot Section Builder
@@ -16,15 +16,21 @@ Parse `$ARGUMENTS`:
 - **`--cf7` flag** = force CF7 contact form integration (optional)
 - **`--page <slug>`** = read the section from `demo/<slug>.html` instead of `demo/index.html` (optional, **default `index`** — existing behavior unchanged when omitted)
 - **`--target <template>`** = inject the `get_template_part` call into `<template>` (e.g. `page-about.php`) instead of `front-page.php` (optional, **default `front-page.php`** — existing behavior unchanged when omitted)
+- **`--transcribe` flag** = activate **faithful Transcription Mode** (optional). When set, the dispatched agents reproduce the demo's exact declared CSS/geometry instead of re-authoring fresh design-system styles. When omitted, behavior is unchanged (the current re-authoring / design-system path).
+- **`--block <name>`** = the unique BEM block name to scope every generated selector under (optional; used with `--transcribe` so parallel section builds can never collide on a selector).
+- **`--css <source>`** = the section's verbatim demo CSS to transcribe from (optional; the SOURCE OF TRUTH for `--transcribe`). May be an inline CSS blob or a path to a CSS file.
+
+> **Note:** `/wp-yolo` sets `--transcribe --block <block> --css <cssRules>` on every `/wp-section` dispatch (see `commands/wp-yolo.md` Step 4). When invoked by hand without these flags, `/wp-section` keeps its original design-system authoring behavior.
 
 If no section name is provided, print an error:
 ```
 Error: Section name is required.
-Usage: /wp-section <section-name> [screenshot-path] [--cf7] [--page <slug>] [--target <template>]
+Usage: /wp-section <section-name> [screenshot-path] [--cf7] [--page <slug>] [--target <template>] [--transcribe] [--block <name>] [--css <source>]
 Example: /wp-section hero
          /wp-section services /path/to/screenshot.png
          /wp-section contact --cf7
          /wp-section about-story --page about --target page-about.php
+         /wp-section hero --transcribe --block home-hero --css demo/index.css
 ```
 
 ## Step 2: Read Project Context
@@ -79,6 +85,24 @@ Subfields:      <element> only          (e.g., title, description, icon — NO s
 Field keys:     field_<section>_<element>
 Group keys:     group_<section>
 ```
+
+---
+
+### TRANSCRIPTION MODE OVERLAY (only when `--transcribe` is set)
+
+When `--transcribe` is present (the `/wp-yolo` path), layer these instructions onto every
+agent prompt below. When it is absent, skip this overlay entirely — the agents run their
+normal design-system authoring path unchanged.
+
+- **wp-css:** append to its prompt the literal word **"transcribe"**, the `--css` source
+  (the section's verbatim demo CSS — inline it, or tell the agent to read the given path),
+  and the `--block` name. This activates wp-css **Transcription Mode** (see
+  `agents/wp-css.md`): the demo CSS is the SOURCE OF TRUTH — copy its exact declared values
+  and geometry, do NOT re-author, and scope every selector under `--block`.
+- **wp-template:** instruct it to scope all BEM classes under the `--block` name (use
+  `<block>__<element>` instead of `<section>__<element>`) so the transcribed CSS and the
+  markup share the same unique block and parallel sections never collide.
+- Because each section's `--block` is unique, parallel agents can never clash on a selector.
 
 ---
 

--- a/commands/wp-seed.md
+++ b/commands/wp-seed.md
@@ -174,6 +174,21 @@ bash -c "HERO_IMG_ID=\$($WP media import 'https://images.unsplash.com/photo-xxx'
 
 Store all successful attachment IDs mapped to their target ACF field names.
 
+### Seed assets by role
+
+If the manifest (produced by `wp-normalize`) has a top-level `assets[]` array, each entry carries a `role` (`logo|nav-graphic|hero|content`) plus optional `page`/`field`. After importing, route each asset by role — do not fall back to the generic field-mapping table for these:
+
+- **`logo`** → sideload the file, then set the site logo option:
+  ```bash
+  bash -c "LOGO_ID=\$($WP media import '<file>' --title='Site Logo' --porcelain) && $WP eval \"update_field('site_logo', \$LOGO_ID, 'option');\""
+  ```
+- **`hero`** (per page) → sideload, then set that page's `inner_hero_image` field on the page identified by `asset.page`:
+  ```bash
+  bash -c "HERO_ID=\$($WP media import '<file>' --title='<Page> Hero' --porcelain) && $WP eval \"update_field('inner_hero_image', \$HERO_ID, <page_id>);\""
+  ```
+- **`content`** → sideload, then set the ACF field named in `asset.field` using the normal Phase 4 flow (options page or page-specific, per the field mapping table).
+- **`nav-graphic`** → sideload and register as a theme asset only (e.g. an `nav_graphic` field or enqueued static asset). **Never** assign a `nav-graphic` to `site_logo` or any content field — a mis-tagged nav graphic must not become the seeded logo.
+
 ---
 
 ## Phase 4: Seed ACF Fields (Primary Language)

--- a/commands/wp-yolo.md
+++ b/commands/wp-yolo.md
@@ -104,12 +104,19 @@ Drive the existing commands/agents in this exact order, reading everything from 
    section walk: walk its `sections[]` in order and run the `/wp-section` procedure per
    section (defaults: `--page index`, `--target front-page.php`, so no flags are needed
    for home):
-   - `kind: "static"` → normal `/wp-section <name>` (three-agent parallel dispatch).
+   - `kind: "static"` → normal `/wp-section <name>` (three-agent parallel dispatch). Pass
+     each dispatched `wp-css`/`wp-template` agent this section's `block` (its assigned
+     unique BEM name — scope every selector under it) and its verbatim `cssRules`, with the
+     instruction **"transcribe"** — this activates wp-css Transcription Mode, which
+     reproduces the demo's exact declared CSS under that block instead of drafting fresh
+     styles. Because every section's `block` is already unique, parallel agents can never
+     collide on a selector.
    - `kind: "cpt-teaser"` → **SKIP** — do NOT dispatch `/wp-section` for these. The CPT's
      teaser `template-parts/section-<cpt>.php` was already built and injected into
      `front-page.php` by that CPT's `/wp-cpt` run in step 2. Note it in the report as
      "teaser for `<cpt>`, built by /wp-cpt".
-   - `kind: "contact"` → `/wp-section <name> --cf7`.
+   - `kind: "contact"` → `/wp-section <name> --cf7`, same `block`/`cssRules`/transcribe
+     dispatch as `static`.
 6. **Inner pages** — for every `pages[role=inner]` entry: if the scope reconciliation
    (Step 2.5) marked this page `delivery: idx` or `delivery: plugin`, skip the normal
    page/section flow entirely and instead run
@@ -117,8 +124,11 @@ Drive the existing commands/agents in this exact order, reading everything from 
    Otherwise, run `/wp-page custom <slug>`, then build its `sections[]` — but each inner
    section must read from its OWN demo page and inject into its OWN page template, so pass
    `--page <slug> --target page-<slug>.php` on every dispatch:
-   - `kind: "static"` → `/wp-section <name> --page <slug> --target page-<slug>.php`.
-   - `kind: "contact"` → `/wp-section <name> --cf7 --page <slug> --target page-<slug>.php`.
+   - `kind: "static"` → `/wp-section <name> --page <slug> --target page-<slug>.php`, passing
+     the section's `block` + `cssRules` and the "transcribe" instruction, exactly as in
+     step 5.
+   - `kind: "contact"` → `/wp-section <name> --cf7 --page <slug> --target page-<slug>.php`,
+     same `block`/`cssRules`/transcribe dispatch.
    - `kind: "cpt-teaser"` on an inner page → same skip rule as step 5 (owned by `/wp-cpt`).
    Under `--careful`, confirm with the user before building each inner page.
 7. **`cpt-archive` pages** — no WP Page is created for these (their archive URL is
@@ -132,6 +142,20 @@ Drive the existing commands/agents in this exact order, reading everything from 
    synthesized from the derived design (shared header/footer, design tokens, section
    styling) so they read as native to the site.
 
+## Step 4.5: Font carry
+
+Before seeding, collect every `section.fonts[]` entry across the manifest (dedupe by
+`family`+`weight`+`style`):
+- Copy each entry's `src` woff2 file(s) from the demo folder into `theme/assets/fonts/`.
+- Re-emit each `@font-face` rule with `src` rewritten to the theme-relative path
+  (`assets/fonts/<file>.woff2`) and enqueue the resulting stylesheet (or add to the
+  theme's existing fonts partial) so every block's `transcribe`d CSS resolves against a
+  self-hosted font, not the demo's original path.
+- Only add a Google Fonts `<link rel="preconnect">` (fonts.googleapis.com /
+  fonts.gstatic.com) when the demo's own `<head>` actually references Google Fonts — never
+  as a substitute for a self-hosted font family found in `section.fonts[]`. Self-hosted
+  stays self-hosted; the two are not interchangeable.
+
 ## Step 5: Phase 3 — Seed & Finish
 
 Run, in order:
@@ -139,6 +163,8 @@ Run, in order:
    `page-<slug>.php` auto-applies), populate ACF fields from extracted text in the
    **primary language only** (flag secondary-language strings as untranslated), sideload
    images into the media library and wire them to fields, and build menus from the nav.
+   Pass the manifest's top-level `assets[]` (role-tagged: `logo` / `nav-graphic` / `hero` /
+   `content`) through so `/wp-seed` seeds each image by its role instead of guessing.
    Set `--exclude-slugs` to the comma-joined slugs of every `pages[role=cpt-archive]` entry
    (e.g. `--exclude-slugs team`) so no stray WP Page is created for an archive slug — its
    URL comes from `has_archive`, and a WP Page would collide with `archive-<cpt>.php`.

--- a/commands/wp-yolo.md
+++ b/commands/wp-yolo.md
@@ -140,7 +140,9 @@ Drive the existing commands/agents in this exact order, reading everything from 
    - `/wp-page search`
    These are never conditional on the demo containing a matching page; they are
    synthesized from the derived design (shared header/footer, design tokens, section
-   styling) so they read as native to the site.
+   styling) so they read as native to the site. When the demo has no 404/search page,
+   they are still built as fully styled theme templates — the `/wp-page` runs overwrite
+   any starter/underscores boilerplate `404.php`/`search.php`, never leaving it in place.
 
 ## Step 4.5: Font carry
 

--- a/commands/wp-yolo.md
+++ b/commands/wp-yolo.md
@@ -104,19 +104,19 @@ Drive the existing commands/agents in this exact order, reading everything from 
    section walk: walk its `sections[]` in order and run the `/wp-section` procedure per
    section (defaults: `--page index`, `--target front-page.php`, so no flags are needed
    for home):
-   - `kind: "static"` → normal `/wp-section <name>` (three-agent parallel dispatch). Pass
-     each dispatched `wp-css`/`wp-template` agent this section's `block` (its assigned
-     unique BEM name — scope every selector under it) and its verbatim `cssRules`, with the
-     instruction **"transcribe"** — this activates wp-css Transcription Mode, which
-     reproduces the demo's exact declared CSS under that block instead of drafting fresh
-     styles. Because every section's `block` is already unique, parallel agents can never
-     collide on a selector.
+   - `kind: "static"` → `/wp-section <name> --transcribe --block <block> --css <cssRules>`
+     (three-agent parallel dispatch). The `--transcribe` flag activates wp-css Transcription
+     Mode via `/wp-section`'s transcription overlay; `--block` is the section's assigned
+     unique BEM name (every selector is scoped under it); `--css` is its verbatim demo
+     `cssRules` (the source of truth). This reproduces the demo's exact declared CSS under
+     that block instead of drafting fresh styles. Because every section's `block` is already
+     unique, parallel agents can never collide on a selector.
    - `kind: "cpt-teaser"` → **SKIP** — do NOT dispatch `/wp-section` for these. The CPT's
      teaser `template-parts/section-<cpt>.php` was already built and injected into
      `front-page.php` by that CPT's `/wp-cpt` run in step 2. Note it in the report as
      "teaser for `<cpt>`, built by /wp-cpt".
-   - `kind: "contact"` → `/wp-section <name> --cf7`, same `block`/`cssRules`/transcribe
-     dispatch as `static`.
+   - `kind: "contact"` → `/wp-section <name> --cf7 --transcribe --block <block> --css <cssRules>`,
+     same transcribe dispatch as `static`.
 6. **Inner pages** — for every `pages[role=inner]` entry: if the scope reconciliation
    (Step 2.5) marked this page `delivery: idx` or `delivery: plugin`, skip the normal
    page/section flow entirely and instead run
@@ -124,11 +124,11 @@ Drive the existing commands/agents in this exact order, reading everything from 
    Otherwise, run `/wp-page custom <slug>`, then build its `sections[]` — but each inner
    section must read from its OWN demo page and inject into its OWN page template, so pass
    `--page <slug> --target page-<slug>.php` on every dispatch:
-   - `kind: "static"` → `/wp-section <name> --page <slug> --target page-<slug>.php`, passing
-     the section's `block` + `cssRules` and the "transcribe" instruction, exactly as in
-     step 5.
-   - `kind: "contact"` → `/wp-section <name> --cf7 --page <slug> --target page-<slug>.php`,
-     same `block`/`cssRules`/transcribe dispatch.
+   - `kind: "static"` → `/wp-section <name> --page <slug> --target page-<slug>.php --transcribe --block <block> --css <cssRules>`,
+     passing the section's unique `block` + verbatim `cssRules` via the transcribe flags,
+     exactly as in step 5.
+   - `kind: "contact"` → `/wp-section <name> --cf7 --page <slug> --target page-<slug>.php --transcribe --block <block> --css <cssRules>`,
+     same transcribe dispatch.
    - `kind: "cpt-teaser"` on an inner page → same skip rule as step 5 (owned by `/wp-cpt`).
    Under `--careful`, confirm with the user before building each inner page.
 7. **`cpt-archive` pages** — no WP Page is created for these (their archive URL is

--- a/commands/wp-yolo.md
+++ b/commands/wp-yolo.md
@@ -177,9 +177,47 @@ Run, in order:
 4. **`/wp-polish`**
 5. **`/wp-responsive-check`**
 
+## Step 5.5: Demo-parity gate — auto-fix|auto fix, re-verify, block
+
+`/wp-finalize` (Step 5, item 3 above) already ran the 3-layer demo-parity gate (Layers 1-3).
+Before this run can report success, walk every **critical** finding from that gate:
+
+1. **Auto-fix mechanical findings** — no judgment required, apply directly:
+   - Token-drifted value with a clear literal source in the demo → replace it with the
+     demo's literal value.
+   - Missing font → copy the woff2 file(s) into `theme/assets/fonts/` and re-emit the
+     `@font-face` rule (same as Step 4.5's font carry).
+   - Missing logo/hero asset → seed it by its manifest `role` (`logo` / `hero`), same as
+     `/wp-seed`'s role-tagged asset pass.
+   - Colliding block (unscoped generic class) → rename/rescope it to its manifest-assigned
+     unique `block` name.
+   - Missing `background:url()` → transcribe it verbatim from the demo's recorded CSS
+     (`section.backgrounds` in the manifest) into the theme CSS.
+2. **Re-verify|re-run** — after applying any auto-fix, re-run the affected gate layer(s) to
+   confirm the finding actually cleared. Do not assume the fix worked; re-run and check.
+3. **Ambiguous findings are reported, not guessed.** Value drift with no clear literal
+   source, or a layout mismatch needing design judgment, is never auto-fixed — add it
+   verbatim to the blocking **Review** list.
+4. **Any critical finding still open after auto-fix + re-verify — including everything
+   ambiguous — blocks delivery.** This applies **even under `--yolo`**: `/wp-yolo` does not report success while any critical remains. The run is marked incomplete and the
+   Review list is printed prominently at the top of Step 6's report, before the rest of
+   the summary.
+
 ## Step 6: Report
 
-Print a summary:
+If any critical demo-parity finding survived Step 5.5's auto-fix + re-verify, do NOT
+print "Build Complete." Print instead, before anything else:
+```
+=== WP YOLO Build INCOMPLETE — demo-parity gate blocked delivery ===
+
+Review (blocking):
+  - <every unresolved critical finding — layer, selector/property/file, demo value vs. built value>
+
+Run /wp-finalize again after resolving the above, then re-run this gate.
+```
+This applies under `--yolo` too — `--yolo` skips the Step 3 checkpoint, not this gate.
+
+Otherwise, print a summary:
 ```
 === WP YOLO Build Complete ===
 Pages built:       <slug list, with section counts>

--- a/commands/wp-yolo.md
+++ b/commands/wp-yolo.md
@@ -177,7 +177,7 @@ Run, in order:
 4. **`/wp-polish`**
 5. **`/wp-responsive-check`**
 
-## Step 5.5: Demo-parity gate — auto-fix|auto fix, re-verify, block
+## Step 5.5: Demo-parity gate — auto-fix, re-verify, and block
 
 `/wp-finalize` (Step 5, item 3 above) already ran the 3-layer demo-parity gate (Layers 1-3).
 Before this run can report success, walk every **critical** finding from that gate:
@@ -193,7 +193,7 @@ Before this run can report success, walk every **critical** finding from that ga
      unique `block` name.
    - Missing `background:url()` → transcribe it verbatim from the demo's recorded CSS
      (`section.backgrounds` in the manifest) into the theme CSS.
-2. **Re-verify|re-run** — after applying any auto-fix, re-run the affected gate layer(s) to
+2. **Re-verify** — after applying any auto-fix, re-run the affected gate layer(s) to
    confirm the finding actually cleared. Do not assume the fix worked; re-run and check.
 3. **Ambiguous findings are reported, not guessed.** Value drift with no clear literal
    source, or a layout mismatch needing design judgment, is never auto-fixed — add it

--- a/commands/wp-yolo.md
+++ b/commands/wp-yolo.md
@@ -33,6 +33,21 @@ Error: No .claude/CLAUDE.md found. Run /wp-init first to scaffold the project.
 Extract function prefix, theme slug, languages (primary + secondary), template
 (basic|tailwind), and CF plugin (scf|acf) — needed by every downstream command.
 
+**Git baseline gate.** `/wp-yolo` rewrites the theme wholesale, so it must run against
+a git repo — for a rollback point and for worktree isolation. In the theme directory:
+
+```bash
+cd <theme-dir>
+git rev-parse --is-inside-work-tree >/dev/null 2>&1 || {
+  git init -q
+  printf 'node_modules/\n.DS_Store\n*.log\n' > .gitignore
+}
+git add -A && git commit -q -m "chore: baseline before /wp-yolo build" || true
+```
+
+This is unconditional and runs even under `--yolo`: no build starts until a clean
+baseline commit exists, so the whole pass is diffable and revertible.
+
 ## Step 2: Phase 1 — Normalize
 
 Dispatch the **wp-normalize** agent against the demo folder from Step 1. It scans every

--- a/skills/wp-theme-standards/SKILL.md
+++ b/skills/wp-theme-standards/SKILL.md
@@ -583,6 +583,34 @@ add_action('wp_head', 'prefix_add_meta_description', 1);
 
 ---
 
+## Navigation class contract
+
+The nav walker (generates markup) and the header CSS (styles it) MUST agree on one shared set of class names. Use exactly these — do not invent alternates:
+
+| Class | Purpose |
+|---|---|
+| `.nav` | Root nav container |
+| `.nav__menu` | The `<ul>` menu list |
+| `.nav__item` | Each `<li>` menu item |
+| `.nav__item--has-children` | Modifier on items with a dropdown submenu |
+| `.nav__link` | The anchor for a plain (non-dropdown) menu item |
+| `.nav__submenu` | The nested `<ul>` dropdown menu |
+| `.nav__toggle` | The clickable/focusable element that opens a dropdown (e.g. `PROPERTIES ▾`) |
+
+States: `.is-open` (added to `.nav__item--has-children` when its submenu is expanded) and `aria-expanded` (`"true"`/`"false"` attribute on `.nav__toggle`, kept in sync with `.is-open`).
+
+**Baseline alignment rule (mandatory):** toggle items must sit on the same text baseline as plain links — never let the presence of a dropdown arrow shift a label up/down relative to its siblings. Apply `display:flex; align-items:center` to both `.nav__link` and `.nav__toggle`.
+
+```css
+.nav__link,
+.nav__toggle {
+    display: flex;
+    align-items: center;
+}
+```
+
+---
+
 ## Summary Checklist
 
 - [ ] `style.css` has required WordPress headers

--- a/tests/checks/finalize-gate-static.sh
+++ b/tests/checks/finalize-gate-static.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+f=commands/wp-finalize.md
+for token in 'undefined' 'var\(--' 'collision' 'font parity|@font-face' 'background:url|background-image' 'critical'; do
+  grep -Eqi "$token" "$f" || { echo "FAIL: finalize missing static check '$token'"; exit 1; }
+done
+echo PASS

--- a/tests/checks/finalize-gate-visual.sh
+++ b/tests/checks/finalize-gate-visual.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+f=commands/wp-finalize.md
+for token in 'site_logo' 'inner_hero_image' 'claude-in-chrome' 'getComputedStyle' 'hard delta|hard-delta' 'soft delta|soft-delta' 'skip'; do
+  grep -Eqi "$token" "$f" || { echo "FAIL: finalize missing '$token'"; exit 1; }
+done
+grep -Eqi '3%|8px' "$f" || { echo "FAIL: no numeric visual threshold stated"; exit 1; }
+echo PASS

--- a/tests/checks/nav-contract.sh
+++ b/tests/checks/nav-contract.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+s=skills/wp-theme-standards/SKILL.md
+grep -qi 'nav.*class contract\|nav-class contract\|Navigation class contract' "$s" || { echo "FAIL: no nav contract in wp-theme-standards"; exit 1; }
+for c in 'nav__menu' 'nav__item--has-children' 'nav__link' 'nav__submenu' 'nav__toggle'; do
+  grep -q "$c" "$s" || { echo "FAIL: contract missing .$c"; exit 1; }
+done
+grep -qi 'baseline\|align-items' "$s" || { echo "FAIL: contract missing dropdown baseline-alignment rule"; exit 1; }
+grep -q 'nav-class contract\|nav contract\|wp-theme-standards' agents/wp-template.md || { echo "FAIL: wp-template does not reference the contract"; exit 1; }
+grep -q 'nav-class contract\|nav contract\|wp-theme-standards' agents/wp-css.md || { echo "FAIL: wp-css does not reference the contract"; exit 1; }
+echo PASS

--- a/tests/checks/wp-css-tokens.sh
+++ b/tests/checks/wp-css-tokens.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# The wp-css agent must teach the canonical design-token vocabulary (the one the
+# wp-demo + wp-css-system skills and the starter :root actually define), not a
+# private set that resolves to undefined var(--x) in generated CSS.
+set -euo pipefail
+f=agents/wp-css.md
+
+# Known-wrong token names that previously shipped in the agent's examples and caused
+# undefined custom properties in generated section CSS.
+bad='(--color-bg\b|--color-bg-alt\b|--color-text-muted\b|--font-heading\b|--font-body\b|--text-(xs|sm|base|md|lg|xl|2xl|3xl|4xl)\b)'
+hits=$(grep -oE "$bad" "$f" | sort -u || true)
+if [ -n "$hits" ]; then
+  echo "FAIL: wp-css agent references non-canonical token names:"; echo "$hits"; exit 1
+fi
+
+# The agent must carry the token-integrity rule (never emit an undefined var).
+grep -q 'Never emit an undefined' "$f" \
+  || { echo "FAIL: wp-css agent missing the undefined-var integrity rule"; exit 1; }
+
+echo PASS

--- a/tests/checks/wp-css-transcription.sh
+++ b/tests/checks/wp-css-transcription.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+f=agents/wp-css.md
+grep -qi 'Transcription Mode' "$f" || { echo "FAIL: no Transcription Mode section"; exit 1; }
+for token in 'source of truth' 'exact' 'background:url' '@font-face' 'assigned' 'block'; do
+  grep -qi "$token" "$f" || { echo "FAIL: transcription section missing '$token'"; exit 1; }
+done
+# Must forbid the specific 'improvements' that changed measured output.
+grep -qi 'min-height' "$f" || { echo "FAIL: does not call out the 44px touch-target trap"; exit 1; }
+echo PASS

--- a/tests/checks/wp-normalize-fidelity.sh
+++ b/tests/checks/wp-normalize-fidelity.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+f=agents/wp-normalize.md
+for token in 'block' 'cssRules' 'backgrounds' '@font-face' 'computed' 'role' 'nav-graphic' 'hero' 'shared component'; do
+  grep -qi "$token" "$f" || { echo "FAIL: missing '$token'"; exit 1; }
+done
+grep -qi 'unique' "$f" || { echo "FAIL: does not state block names are unique/assigned"; exit 1; }
+echo PASS

--- a/tests/checks/wp-seed-roles.sh
+++ b/tests/checks/wp-seed-roles.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+f=commands/wp-seed.md
+for token in 'role' 'site_logo' 'inner_hero_image' 'nav-graphic'; do
+  grep -q "$token" "$f" || { echo "FAIL: wp-seed missing '$token' role handling"; exit 1; }
+done
+grep -qi 'teaser' agents/wp-template.md || { echo "FAIL: wp-template missing teaser-fidelity note"; exit 1; }
+echo PASS

--- a/tests/checks/wp-yolo-fidelity.sh
+++ b/tests/checks/wp-yolo-fidelity.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+f=commands/wp-yolo.md
+for token in 'transcribe' 'block' 'assets/fonts' '@font-face' 'role'; do
+  grep -qi "$token" "$f" || { echo "FAIL: wp-yolo missing '$token'"; exit 1; }
+done
+grep -qi 'google fonts' "$f" || { echo "FAIL: wp-yolo does not state self-hosted-vs-Google-fonts rule"; exit 1; }
+echo PASS

--- a/tests/checks/wp-yolo-gate.sh
+++ b/tests/checks/wp-yolo-gate.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+f=commands/wp-yolo.md
+for token in 'wp-finalize' 'auto-fix\|auto fix' 'block' 'Review' 're-verify\|re-run'; do
+  grep -Eqi "$token" "$f" || { echo "FAIL: wp-yolo gate missing '$token'"; exit 1; }
+done
+grep -Eqi 'does not (report|claim) success|marked incomplete' "$f" || { echo "FAIL: does not state --yolo blocks on critical"; exit 1; }
+echo PASS

--- a/tests/checks/wp-yolo-gate.sh
+++ b/tests/checks/wp-yolo-gate.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 f=commands/wp-yolo.md
-for token in 'wp-finalize' 'auto-fix\|auto fix' 'block' 'Review' 're-verify\|re-run'; do
+for token in 'wp-finalize' 'auto-fix|auto fix' 'block' 'Review' 're-verify|re-run'; do
   grep -Eqi "$token" "$f" || { echo "FAIL: wp-yolo gate missing '$token'"; exit 1; }
 done
 grep -Eqi 'does not (report|claim) success|marked incomplete' "$f" || { echo "FAIL: does not state --yolo blocks on critical"; exit 1; }

--- a/tests/fixtures/fidelity-demo/EXPECTED-GATE.md
+++ b/tests/fixtures/fidelity-demo/EXPECTED-GATE.md
@@ -1,0 +1,78 @@
+# Expected: `/wp-yolo` fidelity + gate behavior for `fidelity-demo/`
+
+Hand-traced oracle for this adversarial fixture. Every assertion below is cross-checked
+against the documented behavior of `agents/wp-normalize.md`, `commands/wp-finalize.md`, and
+`commands/wp-yolo.md` on this branch — not invented.
+
+## The fixture's traps (one per failure class)
+
+| Trap | Where | Why it breaks a re-authoring pipeline |
+|------|-------|----------------------------------------|
+| `.services` on BOTH pages | `index.html` + `services.html` (one `.services` rule in `styles.css`) | Split into two per-page section files, `.services` collides when bundled into one stylesheet. |
+| CSS `background:url()` (no `<img>`) | `.home-hero` / `.sp-hero` in `styles.css` | A markup-only pass copies `<img>` only; the hero backgrounds silently vanish. |
+| `@font-face` self-hosted | `Brand Sans` → `fonts/brand-sans-regular.woff2` | Font never carried → renders in a system fallback. |
+| Per-page hero background | `hero-home.jpg` vs `hero-services.jpg` | Distinct per-page image never seeded → blank hero. |
+| Header nav-graphic ≠ logo | `logo.svg` (role logo) vs `nav-icon.svg` (`.nav-toggle`, role nav-graphic) | Nav graphic mis-set as `site_logo`. |
+| Literal `color:#BFBFBF` | `.services .note` | Mapped to nearest token (`--color-gray` #848484) instead of copied. |
+
+## Expected `wp-normalize` manifest annotations
+
+- **Unique blocks assigned** (not requested): the two `.services` sections →
+  `home-services` and `sp-services`; heroes → `home-hero` / `sp-hero`.
+- **`section.cssRules`** carries the verbatim declared CSS for each section (so `wp-css`
+  transcribes, not guesses) — including `.services .note { color:#BFBFBF }` byte-for-byte.
+- **`section.backgrounds`**: `["images/hero-home.jpg"]` (home hero), `["images/hero-services.jpg"]` (services hero).
+- **`section.fonts`**: `[{ family:"Brand Sans", weight:"400", style:"normal", src:["fonts/brand-sans-regular.woff2"] }]` on the sections that use it.
+- **`section.computed`**: `{height:480}` (home hero), `{height:320}` (services hero).
+- **top-level `assets[]`** (role-tagged):
+  - `logo.svg` → `role:"logo"`
+  - `nav-icon.svg` → `role:"nav-graphic"`  ← NOT logo
+  - `hero-home.jpg` → `role:"hero", page:"index"`
+  - `hero-services.jpg` → `role:"hero", page:"services"`
+
+## Expected build (`/wp-yolo`, Phase 2 transcription)
+
+- Each `wp-css` dispatch gets its `block` + `cssRules` and transcribes literally:
+  - `.services .note` color stays **`#BFBFBF`** — NOT token-mapped. (Failure #1 avoided.)
+  - hero `background:url()` is transcribed into the section CSS. (Failure #3 avoided.)
+  - no `min-height:44px` / textarea resizing / value rounding added.
+- Selectors scoped under the assigned block → `home-services` and `sp-services` never both
+  emit bare `.services`. (Collision structurally impossible.)
+- **Fonts carried:** `brand-sans-regular.woff2` → `theme/assets/fonts/`, `@font-face` re-emitted
+  with rewritten `src`, enqueued. No Google-Fonts preconnect (the demo uses none).
+- **Assets seeded by role** (Phase 3): `logo.svg` → `site_logo`; `hero-home.jpg`/`hero-services.jpg`
+  → each page's `inner_hero_image`; `nav-icon.svg` → theme asset only, never `site_logo`.
+
+## Expected gate result (`/wp-finalize`, auto-run by `/wp-yolo`)
+
+Auto-fixes applied then re-verified; nothing ambiguous remains, so the build **passes**:
+
+- **Layer 1 (static):**
+  - Collision scan: if two bare `.services` blocks ever reached the bundle, **auto-rename** to
+    `home-services` / `sp-services`. (A shared class scoped under different page blocks would
+    NOT be flagged — this is a true unscoped collision.)
+  - Undefined-var scan: none (values are literals). 
+  - Font parity: `Brand Sans` `@font-face` + `assets/fonts/brand-sans-regular.woff2` present. 
+  - Background presence: both hero `background:url()` present (transcribed) or seeded. 
+- **Layer 2 (WP-CLI):** `site_logo` non-empty; `inner_hero_image` seeded on both pages; menu
+  assigned; pages exist.
+- **Layer 3 (measured, if claude-in-chrome connected + site up):**
+  - `.services .note` computed `color` == `rgb(191,191,191)` (#BFBFBF) — a hex mismatch would be
+    a **hard-delta BLOCK**.
+  - `.home-hero` height ≈ 480px, `.sp-hero` ≈ 320px — off by >3%/8px would **BLOCK**.
+  - heading/body `font-family` resolves to `Brand Sans`, not a system fallback — fallback would
+    **BLOCK**.
+  - hero backgrounds visible; logo renders (not text fallback).
+  - Sub-pixel / antialiasing differences → **WARN only**, never block.
+
+## What would BLOCK if a builder regressed
+
+- `.services` left un-namespaced and colliding → collision scan critical.
+- hero `background:url()` dropped → background-presence critical + Layer-3 missing-background hard delta.
+- `#BFBFBF` token-mapped to `--color-gray` → Layer-3 color hex hard delta.
+- `Brand Sans` not carried → font-parity critical + Layer-3 system-fallback hard delta.
+- `nav-icon.svg` set as `site_logo` → wrong logo renders (caught visually); `site_logo`
+  should be `logo.svg`.
+
+Under `--yolo`, any remaining critical marks the run **incomplete** and prints the Review list;
+`/wp-yolo` does not report success.

--- a/tests/fixtures/fidelity-demo/assets/styles.css
+++ b/tests/fixtures/fidelity-demo/assets/styles.css
@@ -1,0 +1,38 @@
+@font-face {
+  font-family: 'Brand Sans';
+  font-weight: 400;
+  font-style: normal;
+  src: url('fonts/brand-sans-regular.woff2') format('woff2');
+}
+
+.site-header { display: flex; align-items: center; gap: 16px; }
+.logo img { height: 32px; }
+.nav-toggle { height: 20px; width: 20px; }
+
+.home-hero {
+  height: 480px;
+  background: url(images/hero-home.jpg) center/cover no-repeat;
+  color: #fff;
+}
+
+.sp-hero {
+  height: 320px;
+  background: url(images/hero-services.jpg) center/cover no-repeat;
+  color: #fff;
+}
+
+.services {
+  padding: 60px 0;
+  font-family: 'Brand Sans', sans-serif;
+}
+.services .note {
+  color: #BFBFBF;
+}
+.services .card {
+  width: 280px;
+}
+
+@media (max-width: 768px) {
+  .home-hero { height: 320px; }
+  .services { padding: 40px 0; }
+}

--- a/tests/fixtures/fidelity-demo/index.html
+++ b/tests/fixtures/fidelity-demo/index.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Fidelity Demo — Home</title>
+  <link rel="stylesheet" href="assets/styles.css">
+</head>
+<body>
+  <header class="site-header">
+    <a href="index.html" class="logo"><img src="assets/logo.svg" alt="Fidelity Co"></a>
+    <img src="assets/nav-icon.svg" alt="menu" class="nav-toggle">
+    <nav class="nav">
+      <a href="index.html">Home</a>
+      <a href="services.html">Services</a>
+    </nav>
+  </header>
+
+  <!-- ============ SECTION: hero ============ -->
+  <section class="hero home-hero">
+    <h1>Welcome Home</h1>
+    <p>We build things, faithfully.</p>
+  </section>
+  <!-- ============ END SECTION: hero ============ -->
+
+  <!-- ============ SECTION: services ============ -->
+  <section class="services">
+    <h2>Our Services</h2>
+    <p class="note">Consulting, design, and support.</p>
+    <div class="cards">
+      <div class="card">Consulting</div>
+      <div class="card">Design</div>
+    </div>
+  </section>
+  <!-- ============ END SECTION: services ============ -->
+
+  <footer class="site-footer">
+    <p>&copy; 2026 Fidelity Co</p>
+  </footer>
+</body>
+</html>

--- a/tests/fixtures/fidelity-demo/services.html
+++ b/tests/fixtures/fidelity-demo/services.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Fidelity Demo — Services</title>
+  <link rel="stylesheet" href="assets/styles.css">
+</head>
+<body>
+  <header class="site-header">
+    <a href="index.html" class="logo"><img src="assets/logo.svg" alt="Fidelity Co"></a>
+    <img src="assets/nav-icon.svg" alt="menu" class="nav-toggle">
+    <nav class="nav">
+      <a href="index.html">Home</a>
+      <a href="services.html">Services</a>
+    </nav>
+  </header>
+
+  <!-- ============ SECTION: hero ============ -->
+  <section class="hero sp-hero">
+    <h1>Our Services</h1>
+  </section>
+  <!-- ============ END SECTION: hero ============ -->
+
+  <!-- ============ SECTION: services ============ -->
+  <section class="services">
+    <h2>Full Service List</h2>
+    <p class="note">Everything we offer, in detail.</p>
+    <div class="cards">
+      <div class="card">Consulting</div>
+      <div class="card">Design</div>
+      <div class="card">Support</div>
+    </div>
+  </section>
+  <!-- ============ END SECTION: services ============ -->
+
+  <footer class="site-footer">
+    <p>&copy; 2026 Fidelity Co</p>
+  </footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Makes `/wp-yolo` **transcribe** the demo (copy exact declared values) instead of re-authoring it, gives every asset an explicit owner, and adds a layered **demo-parity verification gate** that blocks the build while the theme diverges from the demo. This closes the whole class of "renders wrong" bugs (wrong colors, changed heights, dropped CSS backgrounds, class collisions, unseeded logo/hero, mismatched teaser). Includes the `wp-css` token-vocabulary fix (undefined-`var(--x)` prevention) it builds on.

### Prevention — faithful builders + asset owners
- **`wp-css` Transcription Mode** (yolo path): copies exact `color`/`height`/`gap`/`background` values, captures CSS `background:url()` + `@font-face`, no best-practice edits that change measured geometry, tokenizes only on an exact match. Explicitly overrides the token/44px doctrine on the yolo path (standalone `/wp-section` keeps it).
- **`wp-normalize`** captures the full CSS surface (verbatim `cssRules`, backgrounds, `@font-face`, computed dims), tags **asset roles** (`logo | nav-graphic | hero | content`), and **assigns unique BEM blocks up front** so parallel agents can't collide on generic names.
- **`/wp-section`** gains `--transcribe`/`--block`/`--css` passthrough so `/wp-yolo` actually activates Transcription Mode on the real dispatch path.
- **`/wp-seed`** seeds by role (logo → `site_logo`, per-page hero → `inner_hero_image`, nav-graphic never mis-set as logo). Self-hosted fonts carried to `assets/fonts/`. Shared **nav-class contract** (walker + header CSS agree, incl. dropdown baseline alignment).

### Detection — the gate (`/wp-finalize`, auto-run by `/wp-yolo`)
- **Layer 1 static:** undefined-`var(--x)`, CSS class-collision scan (shared-under-different-blocks is NOT flagged), font parity, background-image presence, nav-contract match.
- **Layer 2 WP-CLI:** `site_logo`/`inner_hero_image` seeded, menus, pages.
- **Layer 3 measured visual (claude-in-chrome when connected):** `getComputedStyle` deltas vs the demo — hard deltas (hex mismatch, missing background, dim off >3%/8px, font system-fallback) **block**; sub-pixel/antialiasing **warn**; graceful skip when the extension/site is unavailable.
- Critical findings auto-fix mechanically then re-verify; anything ambiguous blocks — `/wp-yolo` (incl. `--yolo`) does not report success while a divergence remains.

### Verification
Markdown command/agent specs (no runtime code). 8 new grep guards under `tests/checks/` (all pass; 18 total repo-wide) + a `tests/fixtures/fidelity-demo/` adversarial oracle that trips all six failure classes with the expected gate behavior traced against the real command bodies.

### Review trail
Built task-by-task (2 phases, 9 tasks) with per-task spec+quality reviews. The whole-branch review caught 2 Critical (Transcription Mode never reaching `wp-css` via `/wp-section`; logo gate reading core `site_logo` while seed writes the ACF option) + 2 Important + 1 Minor — all fixed and re-verified.

> Note: `fix/wp-css-token-vocab` is subsumed by this PR (its commit `dcad2de` is included), so it needs no separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
