### PR TITLE
Fix PR-Agent API key env var (OPENAI__KEY)

### DIFF
--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -26,7 +26,10 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # Your LiteLLM virtual key (the ONLY secret). Add it in repo Settings →
           # Secrets and variables → Actions → New repository secret → name OPENAI_KEY.
-          OPENAI_KEY: ${{ secrets.OPENAI_KEY }}
+          # Double underscore maps to openai.key in PR-Agent's config (dynaconf),
+          # matching OPENAI__API_BASE below. Single-underscore OPENAI_KEY is NOT
+          # picked up and the tool silently falls back to a 'dummy_key' → LiteLLM 401.
+          OPENAI__KEY: ${{ secrets.OPENAI_KEY }}
           # Model + endpoint are also read from the committed .pr_agent.toml, but
           # setting them here too makes the workflow self-contained and overrides
           # the file if they ever drift. Double-underscore = nested config key.


### PR DESCRIPTION
The workflow used single-underscore OPENAI_KEY, which PR-Agent (dynaconf) does not map to openai.key — it fell back to dummy_key and LiteLLM returned 401 (surfaced as a misleading Connection error). Double underscore OPENAI__KEY fixes it, matching OPENAI__API_BASE.