### PR TITLE
pr-agent: route direct to LiteLLM :4000 (bypass Headroom)

### DIFF
--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -37,10 +37,9 @@ jobs:
           CONFIG__FALLBACK_MODELS: '["openai/coder"]'
           CONFIG__CUSTOM_MODEL_MAX_TOKENS: "65536"
           CONFIG__MAX_MODEL_TOKENS: "48000"
-          # 172.17.0.1 = Docker bridge gateway ("the host" from the action's container).
-          # NOT a machine-specific IP — identical on every Docker host, leaks nothing.
-          # Runner is on the rig, so this is a direct, fast path to Headroom.
-          # (NetBird overlay 100.124.103.120 also works but its tunnel is ~1000x slower
-          #  on large PR diffs → client timeout → "Connection error". Use it only if the
-          #  runner is on a DIFFERENT machine reaching the rig over NetBird.)
-          OPENAI__API_BASE: "http://172.17.0.1:8788/v1"
+          # LiteLLM directly (NOT via Headroom :8788). Headroom short-circuits pr-agent's
+          # request shape (returns empty 200, never forwards) — and since pr-agent uses the
+          # LOCAL free Qwen, Headroom's token compression saves no cost here anyway.
+          # 172.17.0.1 = Docker bridge gateway ("the host" from the action's container):
+          # not a machine-specific IP, identical on every Docker host, leaks nothing.
+          OPENAI__API_BASE: "http://172.17.0.1:4000/v1"

--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -37,4 +37,8 @@ jobs:
           CONFIG__FALLBACK_MODELS: '["openai/coder"]'
           CONFIG__CUSTOM_MODEL_MAX_TOKENS: "65536"
           CONFIG__MAX_MODEL_TOKENS: "48000"
-          OPENAI__API_BASE: "http://100.124.103.120:8788/v1"
+          # Host LAN IP (runner is on the rig): direct, full-MTU path to Headroom.
+          # The NetBird overlay IP (100.124.103.120) also works but its tunnel is
+          # ~1000x slower on large PR diffs → pr-agent client timeout → "Connection error".
+          # Use the overlay IP only if the runner is on a DIFFERENT machine.
+          OPENAI__API_BASE: "http://192.168.0.20:8788/v1"

--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -20,7 +20,7 @@ jobs:
     name: PR-Agent review
     steps:
       - name: Run PR-Agent
-        uses: qodo-ai/pr-agent@main
+        uses: the-pr-agent/pr-agent@main   # community-maintained OSS PR-Agent (Qodo donated it)
         env:
           # Auto-provided by GitHub; lets the bot read the diff and post comments.
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -37,8 +37,10 @@ jobs:
           CONFIG__FALLBACK_MODELS: '["openai/coder"]'
           CONFIG__CUSTOM_MODEL_MAX_TOKENS: "65536"
           CONFIG__MAX_MODEL_TOKENS: "48000"
-          # Host LAN IP (runner is on the rig): direct, full-MTU path to Headroom.
-          # The NetBird overlay IP (100.124.103.120) also works but its tunnel is
-          # ~1000x slower on large PR diffs → pr-agent client timeout → "Connection error".
-          # Use the overlay IP only if the runner is on a DIFFERENT machine.
-          OPENAI__API_BASE: "http://192.168.0.20:8788/v1"
+          # 172.17.0.1 = Docker bridge gateway ("the host" from the action's container).
+          # NOT a machine-specific IP — identical on every Docker host, leaks nothing.
+          # Runner is on the rig, so this is a direct, fast path to Headroom.
+          # (NetBird overlay 100.124.103.120 also works but its tunnel is ~1000x slower
+          #  on large PR diffs → client timeout → "Connection error". Use it only if the
+          #  runner is on a DIFFERENT machine reaching the rig over NetBird.)
+          OPENAI__API_BASE: "http://172.17.0.1:8788/v1"

--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -32,7 +32,7 @@ max_model_tokens = 48000
 # Your LiteLLM proxy. This is a private NetBird address, not a secret, so it's
 # fine to commit. If the Action container can't reach it, see the networking
 # troubleshooting section in README.md.
-api_base = "http://172.17.0.1:8788/v1"
+api_base = "http://172.17.0.1:4000/v1"
 # api_key is intentionally absent here — provided via OPENAI_KEY secret / env.
 
 [pr_reviewer]

--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -32,7 +32,7 @@ max_model_tokens = 48000
 # Your LiteLLM proxy. This is a private NetBird address, not a secret, so it's
 # fine to commit. If the Action container can't reach it, see the networking
 # troubleshooting section in README.md.
-api_base = "http://100.124.103.120:8788/v1"
+api_base = "http://192.168.0.20:8788/v1"
 # api_key is intentionally absent here — provided via OPENAI_KEY secret / env.
 
 [pr_reviewer]

--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -32,7 +32,7 @@ max_model_tokens = 48000
 # Your LiteLLM proxy. This is a private NetBird address, not a secret, so it's
 # fine to commit. If the Action container can't reach it, see the networking
 # troubleshooting section in README.md.
-api_base = "http://192.168.0.20:8788/v1"
+api_base = "http://172.17.0.1:8788/v1"
 # api_key is intentionally absent here — provided via OPENAI_KEY secret / env.
 
 [pr_reviewer]


### PR DESCRIPTION
Headroom short-circuits pr-agent request shape (returns empty 200, never forwards -> pr-agent Connection error). Since pr-agent uses the local free Qwen, Headroom compression saves no cost. Point api_base directly at LiteLLM 172.17.0.1:4000. LiteLLM handles the exact request shape (verified: large/2-msg/streaming all OK).