### PR TITLE
feat: WebP image delivery + right-sizing, SEO link-text fix, define .screen-reader-text

### DIFF
--- a/agents/wp-template.md
+++ b/agents/wp-template.md
@@ -126,9 +126,13 @@ endif;
 
 ```php
 $logo = prefix_get_field('site_logo', 'option');
-if ($logo) : ?>
-    <img src="<?php echo esc_url($logo); ?>" alt="<?php echo esc_attr(get_bloginfo('name')); ?>" class="header__logo-img">
-<?php endif; ?>
+// Right-sized + WebP via the helper (see "Image Fields" below); pass an ID-bearing
+// field so a srcset is emitted instead of the full original.
+echo prefix_image($logo, 'medium', array(
+    'class' => 'header__logo-img',
+    'alt'   => get_bloginfo('name'),
+    'sizes' => '160px', // the logo's real display width
+));
 ```
 
 ### Static translated strings
@@ -136,6 +140,49 @@ if ($logo) : ?>
 ```php
 <h2 class="section__title"><?php prefix_e('services_heading'); ?></h2>
 ```
+
+## Image Fields — right-size + WebP (MANDATORY)
+
+**Never emit a raw image-field URL for a fixed-size slot** — `echo $field['url']` always outputs the full-size original (e.g. a 2200px photo in a 400px card), the #1 cause of Lighthouse "responsive-size" / oversized-image waste. Pass the **attachment ID** so WP emits a `srcset`; the starter's `inc/performance.php` output-buffer then rewrites those URLs to `.webp`.
+
+Use the starter helper `prefix_image()` (from `inc/performance.php`) or `wp_get_attachment_image()` directly, and **always set `sizes` to the element's real rendered width**:
+
+```php
+$image = prefix_get_field('about_image');
+// Full-bleed / large content image:
+echo prefix_image($image, 'large', array(
+    'class' => 'about__bg', 'alt' => $heading,
+    'loading' => 'lazy', 'decoding' => 'async',
+    'sizes' => '(max-width: 899px) 100vw, 50vw', // match the CSS display width
+));
+
+// Small fixed slot (logo, icon) — serve a small variant:
+echo prefix_image(prefix_get_field('site_logo', 'option'), 'medium', array(
+    'alt' => get_bloginfo('name'), 'sizes' => '136px',
+));
+```
+
+- Above-the-fold **hero/LCP** image: keep it an `<img>` (not a video) with `fetchpriority="high"` + `width`/`height`, and add a `<link rel="preload" as="image">` for it in `wp_head`. Lazy-load any hero background `<video>` via JS on desktop only, after the poster paints — never on mobile / `navigator.connection.saveData`.
+- `sizes` cheat-sheet: full-bleed → `100vw`; half-width split → `(max-width: 899px) 100vw, 50vw`; fixed logo/icon → its px width (`136px`).
+
+## Descriptive Link Text (SEO — MANDATORY)
+
+Lighthouse's `link-text` SEO audit matches the link's **visible innerText** against a blocklist (`click here`, `here`, `learn more`, `more`, `read more`, `this`, `start`, …). **`aria-label` does NOT satisfy it.** When the demo uses a generic button label (very common: "LEARN MORE", "READ MORE", "VIEW"), append a visually-hidden descriptive suffix **inside** the anchor so innerText becomes descriptive while the button still shows the short label:
+
+```php
+<a class="btn" href="<?php echo esc_url($cta_url); ?>">
+    <?php echo esc_html($cta_label); // e.g. "LEARN MORE" — stays visible ?>
+    <?php if ($context) : ?><span class="screen-reader-text"><?php
+        echo esc_html('about ' . $context); // e.g. the card title
+    ?></span><?php endif; ?>
+</a>
+```
+
+The suffix MUST use `.screen-reader-text` (clip pattern — shipped in `utilities/wordpress.css`), never `display:none` (excluded from innerText → would still fail).
+
+## Meta description — leave it to the SEO plugin
+
+Do **not** emit a hardcoded `<meta name="description">` from the theme `wp_head`. Rank Math / Yoast own it; a theme fallback produces a duplicate-description tag once the plugin is configured.
 
 ## Field Naming Convention
 

--- a/skills/wp-audit-seo-standards/SKILL.md
+++ b/skills/wp-audit-seo-standards/SKILL.md
@@ -781,3 +781,34 @@ $WP eval "echo file_exists(ABSPATH . 'robots.txt') ? 'robots.txt exists' : 'robo
 # Verify llms.txt exists
 $WP eval "echo file_exists(ABSPATH . 'llms.txt') ? 'llms.txt exists' : 'llms.txt missing';"
 ```
+
+---
+
+## 13. Lighthouse SEO Audit Gotchas (hard-won)
+
+Non-obvious traps that make a fix *look* applied while the audit keeps failing. Verify against these before reporting an SEO finding fixed.
+
+### `link-text` matches VISIBLE innerText — not `aria-label`
+
+The Lighthouse `link-text` audit (`core/audits/seo/link-text.js`) lowercases/trims the anchor's **`link.text`** (rendered innerText) and checks it against a blocklist: `click here`, `here`, `learn more`, `more`, `read more`, `this`, `start`, … (per-language). **`aria-label`, `title`, and `nodeLabel` are ignored** — adding an `aria-label` fixes the a11y accessible-name but does **not** satisfy this SEO audit.
+
+To keep a design's non-descriptive label (e.g. a "LEARN MORE" button) *and* pass, append a visually-hidden descriptive suffix **inside** the anchor so it becomes part of innerText:
+
+```php
+<a class="btn" href="<?php echo esc_url( $url ); ?>">
+    <?php echo esc_html( $label ); // e.g. "LEARN MORE" — stays visible ?>
+    <?php if ( $context ) : ?><span class="screen-reader-text"><?php
+        echo esc_html( 'about ' . $context ); // e.g. "about Home Search"
+    ?></span><?php endif; ?>
+</a>
+```
+
+Now `link.text` = "LEARN MORE about Home Search" → not a blocklist match → audit passes; the button still visually reads "LEARN MORE".
+
+- **Critical:** the hidden span must use the `.screen-reader-text` **clip** pattern (`position:absolute; clip: rect(...); width:1px`) — NOT `display:none` or `visibility:hidden`, which are excluded from innerText and would fail again. (A `.screen-reader-text` rule is required in the theme CSS; see a11y standards.)
+- The same non-descriptive label often repeats across a reusable button component — fix the component/template part once, then re-check *every* page that uses it (Lighthouse audits per-URL; a homepage pass doesn't clear inner pages).
+- `identical-links-same-purpose` (a11y, weight 0) can also flag two same-text links (e.g. two "VIEW ALL") pointing to different destinations — the same hidden-suffix technique resolves it.
+
+### Meta description: let the SEO plugin own it — don't emit a theme fallback
+
+If Rank Math (or Yoast) is active and configured, do **not** also `echo` a hardcoded `<meta name="description">` from the theme `wp_head`. Two tags = a duplicate-description warning, and the plugin's dynamic/templated value is the one you want. A common failure mode: a theme adds a front-page meta-description fallback "to be safe" while the SEO plugin's setup wizard was incomplete → once the wizard is finished, the tag is duplicated. Remove the theme fallback; verify only one `<meta name="description">` renders (`curl -s <url> | grep -c 'name="description"'` → `1`).

--- a/skills/wp-audit-standards/SKILL.md
+++ b/skills/wp-audit-standards/SKILL.md
@@ -127,7 +127,67 @@ Lighthouse-style browser audits. Requires the web-quality-skills package for bro
 
 ---
 
-## Auto-Fix Classification
+## Performance — Hard-won Lessons (Tier 3 / Lighthouse)
+
+Interpretation traps and fixes that actually move production bytes. Consult before filing or fixing a `PERF-xxx` finding from a Lighthouse run.
+
+### Read *observed* metrics before chasing a bad *simulated* score
+
+Lighthouse's default (`throttlingMethod: "simulate"`) reports **Lantern-simulated** LCP/FCP/TTI on a modeled slow-4G + 4× CPU. On a **dev server** this is dominated by local TTFB + the throttle model and can read 6–7 s while the page is actually instant. Before treating a high LCP as real, open the full JSON and compare:
+
+- `audits.metrics.details.items[0].largestContentfulPaint` (simulated) **vs** `...observedLargestContentfulPaint` (real paint).
+- If observed is ~200–900 ms and simulated is multi-second, the number is a **simulation/dev-server artifact** — the score barely moves regardless of theme changes, and production (with page cache + real CDN/TTFB) differs. Say so in the finding instead of burning effort chasing it. **Real byte reductions (WebP, right-sizing) still help production** and still shrink the *LCP resource*, so do those — just set score expectations.
+- `image-delivery-insight`, `render-blocking-insight`, `lcp-discovery-insight` etc. are **weight-0** in the Performance score (informative). Only the 5 metric audits (FCP/LCP/TBT/CLS/SI) carry weight. Fixing a weight-0 insight is a production win, not a score win — label it accordingly.
+
+### WebP: `image_editor_output_format` only covers NEW, attachment-pipeline images
+
+`add_filter('image_editor_output_format', ...)` converts uploads to WebP **only on new uploads**, and **only images that flow through WP's attachment functions** (`wp_get_attachment_image`, `the_post_thumbnail`). Themes that print **raw SCF/ACF field URLs** (`echo $field['url']`) or CSS `background-image: url(<field>)` bypass it entirely, so existing hero/about/neighborhood/banner images stay JPEG/PNG.
+
+To serve WebP for **existing + SCF-driven** images without touching every template:
+
+1. Pre-generate `.webp` siblings for existing uploads (one-time): `find uploads -iname '*.jpg' -o -iname '*.png'` → `magick "$f" -quality 82 "${f%.*}.webp"` (hero/LCP images can go lower, ~q68, since they sit behind scrims or are video-replaced).
+2. Add a front-end output-buffer that rewrites finished HTML — covers `src`, `srcset`, and inline `background-image` in one pass:
+
+```php
+add_action( 'template_redirect', function () {
+    if ( is_admin() || is_feed() || is_robots() ) return;
+    $u = wp_get_upload_dir(); $base = $u['baseurl']; $dir = $u['basedir'];
+    ob_start( function ( $html ) use ( $base, $dir ) {
+        $pat = '#' . preg_quote( $base, '#' ) . '/[^"\'\)\s]+?\.(?:jpe?g|png)#i';
+        return preg_replace_callback( $pat, function ( $m ) use ( $base, $dir ) {
+            $webp = preg_replace( '/\.(?:jpe?g|png)$/i', '.webp', $m[0] );
+            return file_exists( $dir . substr( $webp, strlen( $base ) ) ) ? $webp : $m[0];
+        }, $html );
+    } );
+} );
+```
+
+`template_redirect` is front-end-only, and with a page cache (WP Super Cache) the buffer runs once per cache build. WebP is universally supported by target browsers — matching the theme's existing unconditional `image_editor_output_format` policy — so no `Accept`-header branching is needed.
+
+### Right-size — never print `$field['url']` for a fixed slot
+
+Lighthouse "responsive-size" waste = serving a 2200px original in a 400px slot. Raw SCF field URLs (`$image['url']`) always emit the **full original**. Use the attachment ID so the browser gets a `srcset`:
+
+```php
+echo wp_get_attachment_image( (int) $image['id'], 'large', false, array(
+    'class' => 'about__bg', 'alt' => $heading, 'loading' => 'lazy',
+    'sizes' => '(max-width: 899px) 100vw, 136vw', // match the real CSS display width
+) );
+```
+
+Pick `sizes` from the element's actual rendered width (full-bleed → `100vw`; a 136%-wide bg → `136vw`; a 136px logo → `136px`). This composes with the WebP buffer above (the srcset `.jpg` URLs are rewritten to `.webp`).
+
+### Hero LCP pattern (poster-first, video deferred)
+
+Make the LCP element a **small poster image**, not the video: `<img fetchpriority="high" width/height>` + a `<link rel="preload" as="image">` for it in `wp_head`; lazy-load the background `<video>` via JS on **desktop only** (`min-width:1024px`), after the poster paints (`requestIdleCallback`), and **never** on mobile / `navigator.connection.saveData`. Preload the poster's WebP so the preload and the rendered `src` match (else the preload is wasted).
+
+### Render-blocking CSS
+
+Dequeue the near-empty theme `style.css` on the front end (it usually carries only the WP header comment; runtime styles live in the compiled bundle). Async-load below-the-fold plugin CSS (e.g. Contact Form 7) via `style_loader_tag` → `media='print' onload="this.media='all'"`.
+
+### AIOS × Lighthouse gotcha (Tier 2 ↔ Tier 3 interaction)
+
+If the security agent sets AIOS `aiowps_disallow_unauthorized_rest_requests = 1`, it returns **403** on CF7's REST endpoints (`/wp-json/contact-form-7/v1/...`). Lighthouse then **hangs up to 45 s** on those pending requests and logs console errors → Best-Practices drops (often 100 → 96) and metrics inflate. If a CF7 form is present, leave that AIOS setting off (or whitelist the CF7 REST namespace). Symptom in the JSON: `errors-in-console` / pending `Fetch` requests to `contact-form-7` with `statusCode: 403`.
 
 ### Auto-fixable
 

--- a/skills/wp-theme-standards/SKILL.md
+++ b/skills/wp-theme-standards/SKILL.md
@@ -56,6 +56,7 @@ theme-name/
 ├── inc/
 │   ├── theme-setup.php         # Theme supports, nav menus, content width
 │   ├── i18n.php                # Internationalization helpers (if bilingual)
+│   ├── performance.php         # WebP delivery + prefix_image() right-size helper
 │   └── scf-fields.php          # SCF/ACF custom field definitions
 ├── template-parts/
 │   ├── section-hero.php        # Reusable section templates
@@ -360,10 +361,28 @@ function prefix_preload_lcp_image() {
     if (is_front_page()) {
         $hero_image = prefix_get_field('hero_image');
         $hero_image_url = $hero_image ? $hero_image['url'] : prefix_asset('images/hero-image.png');
-        echo '<link rel="preload" as="image" href="' . esc_url($hero_image_url) . '">' . "\n";
+        echo '<link rel="preload" as="image" href="' . esc_url($hero_image_url) . '" fetchpriority="high">' . "\n";
     }
 }
 add_action('wp_head', 'prefix_preload_lcp_image', 2);
+```
+
+The preloaded LCP `<img>` itself must carry `fetchpriority="high"` + `width`/`height`. If the hero is a background video, keep the poster `<img>` as the LCP element and lazy-load the `<video>` via JS on desktop only (never mobile / `navigator.connection.saveData`).
+
+### Image Delivery — WebP + right-sizing (`inc/performance.php`)
+
+Ship `inc/performance.php` (in the starter) in every theme. It handles the image-delivery waste Lighthouse flags, which `image_editor_output_format` alone does **not** cover:
+
+1. `image_editor_output_format` → WebP for new attachment sub-sizes.
+2. `wp_generate_attachment_metadata` → also writes a WebP sibling for the full-size original (so raw-URL / CSS-background usage benefits).
+3. A `template_redirect` output-buffer that rewrites any `uploads/*.jpg|png` with a `.webp` sibling → `.webp` in the finished HTML (covers `src`, `srcset`, and inline `background-image` — including SCF field URLs that bypass WP's attachment pipeline). Runs once per page-cache build.
+4. `prefix_image($field, $size, $attr)` — templates use this instead of `echo $field['url']` so images get a `srcset` sized to the slot. **Always pass `sizes`** matching the real display width (full-bleed `100vw`, split `(max-width: 899px) 100vw, 50vw`, fixed logo `136px`). Serving a 2200px original in a 400px slot is the top oversized-image finding.
+
+For a theme seeded from an existing demo (images already uploaded), batch-generate the `.webp` siblings once so (3) picks them up:
+
+```bash
+find wp-content/uploads -type f \( -iname '*.jpg' -o -iname '*.png' \) \
+  -exec sh -c 'f="$1"; w="${f%.*}.webp"; [ -f "$w" ] || magick "$f" -quality 82 "$w"' _ {} \;
 ```
 
 ### Disable WordPress Emojis

--- a/starter-theme/__tailwind__/assets/css/src/tailwindcss/utilities/wordpress.css
+++ b/starter-theme/__tailwind__/assets/css/src/tailwindcss/utilities/wordpress.css
@@ -10,3 +10,35 @@
 .wp-caption {
   @apply max-w-full mx-auto;
 }
+
+/* Visually-hidden text for screen readers (WP core template-tags rely on this,
+   and it's the correct way to add descriptive text to generic-labelled links —
+   e.g. a "LEARN MORE" button — so Lighthouse's link-text audit sees descriptive
+   innerText. Uses clip (NOT display:none) so the text stays in innerText/the
+   accessibility tree). */
+.screen-reader-text {
+  border: 0;
+  clip: rect(1px, 1px, 1px, 1px);
+  clip-path: inset(50%);
+  height: 1px;
+  width: 1px;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  position: absolute !important;
+  word-wrap: normal !important;
+}
+
+.screen-reader-text:focus {
+  background-color: #f1f1f1;
+  clip: auto !important;
+  clip-path: none;
+  color: #21759b;
+  display: block;
+  height: auto;
+  left: 5px;
+  top: 5px;
+  padding: 15px 23px 14px;
+  width: auto;
+  z-index: 100000;
+}

--- a/starter-theme/__tailwind__/functions.php
+++ b/starter-theme/__tailwind__/functions.php
@@ -17,6 +17,7 @@ require_once __STARTER___DIR . '/inc/cf7-helpers.php';
 require_once __STARTER___DIR . '/inc/nav-walker.php';
 require_once __STARTER___DIR . '/inc/template-tags.php';
 require_once __STARTER___DIR . '/inc/template-functions.php';
+require_once __STARTER___DIR . '/inc/performance.php';
 
 /**
  * Auto-load ACF/SCF field definitions from fields/ directory.

--- a/starter-theme/__tailwind__/inc/performance.php
+++ b/starter-theme/__tailwind__/inc/performance.php
@@ -1,0 +1,112 @@
+<?php
+/**
+ * Performance: image delivery (WebP + right-sizing helpers).
+ *
+ * @package __starter__
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * 1) New uploads: generate WebP for the resized sub-sizes.
+ *
+ * Note this only affects images that later flow through WP's attachment
+ * functions (wp_get_attachment_image, the_post_thumbnail). Templates that print
+ * a raw SCF/ACF field URL (echo $field['url']) or a CSS background-image bypass
+ * it — those are handled by the output-buffer rewrite in (3).
+ */
+add_filter( 'image_editor_output_format', function ( $formats ) {
+	$formats['image/jpeg'] = 'image/webp';
+	$formats['image/png']  = 'image/webp';
+	return $formats;
+} );
+
+/**
+ * 2) On upload, also write a WebP sibling next to the FULL-SIZE original, so
+ * raw-URL and CSS-background usage (which reference the original) can be served
+ * as WebP by (3). WP keeps the original in its uploaded format; this fills that
+ * gap. For a theme seeded from an existing demo, batch-generate the siblings
+ * once (any image with a `.webp` next to it is picked up automatically):
+ *
+ *   find wp-content/uploads -type f \( -iname '*.jpg' -o -iname '*.png' \) \
+ *     -exec sh -c 'f="$1"; w="${f%.*}.webp"; [ -f "$w" ] || magick "$f" -quality 82 "$w"' _ {} \;
+ */
+add_filter( 'wp_generate_attachment_metadata', function ( $metadata, $attachment_id ) {
+	$file = get_attached_file( $attachment_id );
+	if ( ! $file || ! preg_match( '/\.(jpe?g|png)$/i', $file ) ) {
+		return $metadata;
+	}
+	$webp = preg_replace( '/\.(?:jpe?g|png)$/i', '.webp', $file );
+	if ( file_exists( $webp ) ) {
+		return $metadata;
+	}
+	$editor = wp_get_image_editor( $file );
+	if ( ! is_wp_error( $editor ) ) {
+		$editor->save( $webp, 'image/webp' );
+	}
+	return $metadata;
+}, 10, 2 );
+
+/**
+ * 3) Serve WebP for EXISTING + raw-URL + CSS-background images by rewriting the
+ * finished HTML: any wp-content/uploads *.jpg/.png with a `.webp` sibling on
+ * disk is swapped to `.webp` — covering <img src>, srcset, and inline
+ * background-image in one pass. `template_redirect` is front-end only, and with
+ * a page cache the buffer runs once per cache build. WebP is universally
+ * supported by target browsers (matching the unconditional policy in (1)), so
+ * no Accept-header branching is needed.
+ */
+add_action( 'template_redirect', function () {
+	if ( is_admin() || is_feed() || is_robots() ) {
+		return;
+	}
+	$uploads  = wp_get_upload_dir();
+	$base_url = $uploads['baseurl'];
+	$base_dir = $uploads['basedir'];
+
+	ob_start( function ( $html ) use ( $base_url, $base_dir ) {
+		if ( '' === $html ) {
+			return $html;
+		}
+		$pattern = '#' . preg_quote( $base_url, '#' ) . '/[^"\'\)\s]+?\.(?:jpe?g|png)#i';
+		return preg_replace_callback( $pattern, function ( $m ) use ( $base_url, $base_dir ) {
+			$webp = preg_replace( '/\.(?:jpe?g|png)$/i', '.webp', $m[0] );
+			$path = $base_dir . substr( $webp, strlen( $base_url ) );
+			return file_exists( $path ) ? $webp : $m[0];
+		}, $html );
+	} );
+} );
+
+/**
+ * Right-sized <img> from an SCF/ACF image field.
+ *
+ * Prefer this over `echo $field['url']` (which always emits the full-size
+ * original — the #1 cause of Lighthouse "responsive-size" / oversized-image
+ * waste). Passing the attachment ID lets WP emit a srcset the browser can pick
+ * from; the WebP rewrite in (3) then swaps those URLs to `.webp`.
+ *
+ * @param mixed  $field SCF/ACF image field (array with 'id'/'url', or an ID/URL).
+ * @param string $size  Registered image size for the base src (default 'large').
+ * @param array  $attr  Extra attributes. ALWAYS set 'sizes' to the element's
+ *                      real rendered width, e.g. '(max-width: 899px) 100vw, 50vw',
+ *                      a full-bleed hero '100vw', or a fixed logo '136px'.
+ * @return string <img> HTML (empty string if the field is empty).
+ */
+function __starter___image( $field, $size = 'large', $attr = array() ) {
+	$id = is_array( $field ) ? (int) ( $field['id'] ?? 0 ) : ( is_numeric( $field ) ? (int) $field : 0 );
+	if ( $id ) {
+		return wp_get_attachment_image( $id, $size, false, $attr );
+	}
+	// Fallback: a bare URL (e.g. a theme asset) with no attachment behind it.
+	$url = is_array( $field ) ? ( $field['url'] ?? '' ) : (string) $field;
+	if ( ! $url ) {
+		return '';
+	}
+	$out = '<img src="' . esc_url( $url ) . '"';
+	foreach ( $attr as $k => $v ) {
+		$out .= ' ' . esc_attr( $k ) . '="' . esc_attr( $v ) . '"';
+	}
+	return $out . ' />';
+}


### PR DESCRIPTION
## Summary

Bakes the performance + SEO lessons from a real theme optimization pass into **both** the audit standards (so audits *catch* these) and the theme generators (so new themes *avoid* them at build time).

## Starter theme — ships as real code
- **`inc/performance.php`** (new): WebP delivery module
  1. `image_editor_output_format` → WebP for new attachment sub-sizes
  2. `wp_generate_attachment_metadata` hook → also writes a `.webp` sibling for the full-size original (so raw-URL / CSS-background usage benefits)
  3. `template_redirect` output-buffer → rewrites `uploads/*.jpg|png` → `.webp` in the finished HTML when a sibling exists — covers `src`, `srcset`, and inline `background-image`, **including SCF field URLs that bypass WP's attachment pipeline**
  4. `prefix_image()` right-size helper (emit a `srcset` sized to the slot instead of the full original)
- **`functions.php`**: requires the module
- **`utilities/wordpress.css`**: **defines `.screen-reader-text` (+ `:focus`)** — it was *used* across the starter (WP template-tags, content parts) but **never defined** (latent bug); also the class the link-text fix relies on

## Generator agent (`agents/wp-template.md`)
- **Image Fields (mandatory)**: `prefix_image()` / `wp_get_attachment_image` with slot-matched `sizes` — never a raw field url (top oversized-image finding)
- **Descriptive Link Text (mandatory)**: generic labels (e.g. "LEARN MORE") get a `.screen-reader-text` suffix — Lighthouse `link-text` matches **innerText, not `aria-label`**
- Hero LCP poster-first note; don't hardcode meta description; settings-logo example switched to the helper

## Audit standards
- **wp-audit-seo-standards**: "Lighthouse SEO Audit Gotchas" (link-text innerText-vs-aria-label; SEO plugin owns meta description)
- **wp-audit-standards**: "Performance — Hard-won Lessons" (simulated vs observed LCP; WebP for existing/SCF images; right-sizing; hero LCP; render-blocking CSS; AIOS REST 403 hangs Lighthouse)
- **wp-theme-standards**: lists `inc/performance.php`; Image Delivery subsection; `fetchpriority="high"` on the LCP preload

## Notes
- The `.screen-reader-text` fix retroactively repairs a bug affecting every theme built from this starter.
- The WebP rewrite is unconditional (universally supported by target browsers), matching the theme's existing `image_editor_output_format` policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
