### PR TITLE
fix: make generated SCF/ACF field groups editable in the dashboard

### DIFF
--- a/agents/wp-acf.md
+++ b/agents/wp-acf.md
@@ -368,7 +368,7 @@ Multiple conditions in one rule (AND logic — ALL must match):
 
 ## Rules
 
-1. **Files contain BARE `acf_add_local_field_group()` calls** — no hooks, no wrapping functions. The auto-loader handles timing.
+1. **Files contain BARE `acf_add_local_field_group()` calls** — no hooks, no wrapping functions. The auto-loader handles timing. The `fields/*.php` you write are a **one-time bootstrap**: the theme's `acf/init` loader registers them once, persists each group to `acf-json/`, and from then on loads only the Local JSON. This is what makes field groups **editable in the SCF/ACF dashboard** and lets the client add fields manually — pure PHP-local groups (`ID=0`) never appear in the Field Groups list and cannot be edited. Never add a `save_json`/`load_json` filter pointing elsewhere; ACF already defaults to the theme's `acf-json/`.
 2. **One file per section** in the `fields/` directory — `fields/hero.php`, `fields/services.php`, etc.
 3. **Settings fields use `'option'` as post ID** when retrieved via `get_field('field_name', 'option')`
 4. **Location rules:** `page_template` for page-specific fields, `options_page` for settings
@@ -380,6 +380,13 @@ Multiple conditions in one rule (AND logic — ALL must match):
 10. **Always include `if (!defined('ABSPATH')) { exit; }`** at the top of every file
 11. **Image fields:** specify `return_format` ('array' for template flexibility, 'url' for simple display)
 12. **Provide `instructions`** for fields where the purpose is not obvious from the label
+13. **Editing a group that already exists** (e.g. adding fields to `fields/settings.php`): after you change the PHP, the loader will keep loading the old Local JSON unless you invalidate it. Delete that group's `acf-json/<group_key>.json` (and, if the site imported it, `$WP eval "acf_delete_field_group('<group_key>');"` to drop the DB post) so the edited PHP re-bootstraps a fresh JSON on the next load. Do this ONLY when redefining the group in code — it discards any manual dashboard edits to that group, which is the intended behavior for a code-driven change.
+
+## Local JSON model (how these files reach the dashboard)
+
+- `acf_add_local_field_group()` alone = **PHP-local** group: it works on edit screens but has no post (`ID=0`), never shows in **Custom Fields → Field Groups**, and can't be edited. That is a bug, not the goal.
+- The theme's `acf/init` loader bootstraps each `fields/*.php` group **once**, writes it to `acf-json/<key>.json`, then loads only the JSON. ACF/SCF auto-loads `acf-json/`, so the group becomes visible, editable, and two-way synced — dashboard edits (including client-added fields) are written back to the JSON file and stay in version control.
+- Consequence: `fields/*.php` is a **seed**, `acf-json/*.json` is the **source of truth**. Never hand-edit JSON keys; author in PHP and invalidate (rule 13) to regenerate.
 
 ## WP-CLI Integration (when `.wp-create.json` exists)
 

--- a/agents/wp-cinematic.md
+++ b/agents/wp-cinematic.md
@@ -22,7 +22,7 @@ All paths relative to the theme root (`wp-content/themes/<slug>/`).
 
 | File | Purpose |
 |---|---|
-| `fields/scenes.php` | ACF/SCF field group registering a `cinematic_scenes` repeater whose subfields match `scene.json`. Bilingual fields get an `_es` sibling when `languages` includes `es`. |
+| `fields/scenes.php` | ACF/SCF field group registering a `cinematic_scenes` repeater whose subfields match `scene.json`. Bilingual fields get an `_es` sibling when `languages` includes `es`. `fields/*.php` is a bootstrap seed: the theme's `acf/init` loader persists each group to `acf-json/` (the editable source of truth). **When you regenerate `scenes.php`, also delete the scenes group's `acf-json/<group_key>.json` (and `acf_delete_field_group('<group_key>')` if imported to the DB) so the new definition re-bootstraps** — otherwise the loader keeps serving the old JSON. |
 | `fields/trailing-sections.php` | Flex content field for sections appended AFTER the reel. Only when hybrid mode. |
 | `inc/cinematic-loader.php` | Enqueues `cinematic.css`, Lenis + GSAP + ScrollTrigger (CDN), `cinematic-scrubber.js`, and `cinematic-engine.js` (depends on all of them), all deferred. Adds `has-cinematic` body class on cinematic pages, prints `prefers-reduced-motion` guard, declares `cdn.jsdelivr.net` preconnect. |
 | `inc/scenes-renderer.php` | Helpers: `{slug}_cinematic_scenes()` returns repeater rows; `{slug}_cinematic_render_stage($rows)` prints the persistent `.stage`; `{slug}_cinematic_render_scene($row, $index)` prints a single scene. |

--- a/agents/wp-template.md
+++ b/agents/wp-template.md
@@ -126,9 +126,13 @@ endif;
 
 ```php
 $logo = prefix_get_field('site_logo', 'option');
-if ($logo) : ?>
-    <img src="<?php echo esc_url($logo); ?>" alt="<?php echo esc_attr(get_bloginfo('name')); ?>" class="header__logo-img">
-<?php endif; ?>
+// Right-sized + WebP via the helper (see "Image Fields" below); pass an ID-bearing
+// field so a srcset is emitted instead of the full original.
+echo prefix_image($logo, 'medium', array(
+    'class' => 'header__logo-img',
+    'alt'   => get_bloginfo('name'),
+    'sizes' => '160px', // the logo's real display width
+));
 ```
 
 ### Static translated strings
@@ -136,6 +140,49 @@ if ($logo) : ?>
 ```php
 <h2 class="section__title"><?php prefix_e('services_heading'); ?></h2>
 ```
+
+## Image Fields — right-size + WebP (MANDATORY)
+
+**Never emit a raw image-field URL for a fixed-size slot** — `echo $field['url']` always outputs the full-size original (e.g. a 2200px photo in a 400px card), the #1 cause of Lighthouse "responsive-size" / oversized-image waste. Pass the **attachment ID** so WP emits a `srcset`; the starter's `inc/performance.php` output-buffer then rewrites those URLs to `.webp`.
+
+Use the starter helper `prefix_image()` (from `inc/performance.php`) or `wp_get_attachment_image()` directly, and **always set `sizes` to the element's real rendered width**:
+
+```php
+$image = prefix_get_field('about_image');
+// Full-bleed / large content image:
+echo prefix_image($image, 'large', array(
+    'class' => 'about__bg', 'alt' => $heading,
+    'loading' => 'lazy', 'decoding' => 'async',
+    'sizes' => '(max-width: 899px) 100vw, 50vw', // match the CSS display width
+));
+
+// Small fixed slot (logo, icon) — serve a small variant:
+echo prefix_image(prefix_get_field('site_logo', 'option'), 'medium', array(
+    'alt' => get_bloginfo('name'), 'sizes' => '136px',
+));
+```
+
+- Above-the-fold **hero/LCP** image: keep it an `<img>` (not a video) with `fetchpriority="high"` + `width`/`height`, and add a `<link rel="preload" as="image">` for it in `wp_head`. Lazy-load any hero background `<video>` via JS on desktop only, after the poster paints — never on mobile / `navigator.connection.saveData`.
+- `sizes` cheat-sheet: full-bleed → `100vw`; half-width split → `(max-width: 899px) 100vw, 50vw`; fixed logo/icon → its px width (`136px`).
+
+## Descriptive Link Text (SEO — MANDATORY)
+
+Lighthouse's `link-text` SEO audit matches the link's **visible innerText** against a blocklist (`click here`, `here`, `learn more`, `more`, `read more`, `this`, `start`, …). **`aria-label` does NOT satisfy it.** When the demo uses a generic button label (very common: "LEARN MORE", "READ MORE", "VIEW"), append a visually-hidden descriptive suffix **inside** the anchor so innerText becomes descriptive while the button still shows the short label:
+
+```php
+<a class="btn" href="<?php echo esc_url($cta_url); ?>">
+    <?php echo esc_html($cta_label); // e.g. "LEARN MORE" — stays visible ?>
+    <?php if ($context) : ?><span class="screen-reader-text"><?php
+        echo esc_html('about ' . $context); // e.g. the card title
+    ?></span><?php endif; ?>
+</a>
+```
+
+The suffix MUST use `.screen-reader-text` (clip pattern — shipped in `utilities/wordpress.css`), never `display:none` (excluded from innerText → would still fail).
+
+## Meta description — leave it to the SEO plugin
+
+Do **not** emit a hardcoded `<meta name="description">` from the theme `wp_head`. Rank Math / Yoast own it; a theme fallback produces a duplicate-description tag once the plugin is configured.
 
 ## Field Naming Convention
 

--- a/commands/wp-finalize.md
+++ b/commands/wp-finalize.md
@@ -105,9 +105,17 @@ Verify required WordPress theme files and configurations:
 
 1. **acf_add_options_page** (or `acf_add_options_sub_page`) is called somewhere in `functions.php` or `inc/` files
 2. **fields/settings.php** exists and is not empty
-3. **Settings file is included** — check that `fields/settings.php` is `require`d or `include`d from `functions.php` or another loaded file
+3. **Settings group resolves at runtime** — the `acf/init` loader bootstraps `fields/*.php` and persists them to `acf-json/`, so don't grep for an individual `require` of settings.php. Instead confirm the group is live:
+   ```bash
+   $WP eval "\$g=acf_get_field_group('group_settings'); echo \$g && count(acf_get_fields('group_settings')) ? 'OK' : 'MISSING';"
+   ```
+4. **Field groups are dashboard-editable (Local JSON)** — verify no field group is stuck PHP-local (`ID=0`, invisible in the admin list):
+   ```bash
+   $WP eval "\$n=0; foreach(acf_get_field_groups() as \$g){ if((\$g['local']??'')==='php') \$n++; } echo \$n===0 ? 'OK: all groups editable' : \"FAIL: \$n php-local groups\";"
+   ```
+   If any are php-local, `acf-json/` is missing or unwritable — confirm the loader ran and the directory is writable.
 
-**PASS** if settings page is properly registered and has fields. **FAIL** with details.
+**PASS** if the settings group resolves, has fields, and no group is php-local. **FAIL** with details.
 
 ---
 

--- a/commands/wp-settings.md
+++ b/commands/wp-settings.md
@@ -56,11 +56,28 @@ Dispatch the **wp-acf** agent with these instructions:
 > 6. Add helpful instructions/descriptions to fields so the client understands what each one does
 > 7. All fields should have `field_` prefixed keys
 > 8. Ensure the field group location rule keeps pointing to the options page
+> 9. After editing the file, invalidate the group's Local JSON so the change
+>    re-bootstraps (the loader skips PHP for groups that already have JSON):
+>    delete `acf-json/group_settings.json` and, if the site imported it, run
+>    `$WP eval "acf_delete_field_group('group_settings');"`. The next WP load
+>    regenerates `acf-json/group_settings.json` from the edited PHP. This
+>    discards any manual dashboard edits to the settings group — intended for a
+>    code-driven change.
 >
 > **Existing settings.php content:**
 > ```php
 > <paste current file content>
 > ```
+
+## Step 4b: Regenerate Local JSON
+
+After the agent updates `fields/settings.php` and removes the stale JSON, trigger
+a bootstrap pass so the group is rewritten to `acf-json/` and stays dashboard-editable:
+
+```bash
+$WP eval "acf_get_field_groups();" >/dev/null 2>&1
+$WP eval "\$g=acf_get_field_group('group_settings'); echo \$g ? 'settings OK: '.count(acf_get_fields('group_settings')).' fields' : 'MISSING';"
+```
 
 ## Step 5: Print Summary
 

--- a/skills/wp-audit-seo-standards/SKILL.md
+++ b/skills/wp-audit-seo-standards/SKILL.md
@@ -781,3 +781,34 @@ $WP eval "echo file_exists(ABSPATH . 'robots.txt') ? 'robots.txt exists' : 'robo
 # Verify llms.txt exists
 $WP eval "echo file_exists(ABSPATH . 'llms.txt') ? 'llms.txt exists' : 'llms.txt missing';"
 ```
+
+---
+
+## 13. Lighthouse SEO Audit Gotchas (hard-won)
+
+Non-obvious traps that make a fix *look* applied while the audit keeps failing. Verify against these before reporting an SEO finding fixed.
+
+### `link-text` matches VISIBLE innerText — not `aria-label`
+
+The Lighthouse `link-text` audit (`core/audits/seo/link-text.js`) lowercases/trims the anchor's **`link.text`** (rendered innerText) and checks it against a blocklist: `click here`, `here`, `learn more`, `more`, `read more`, `this`, `start`, … (per-language). **`aria-label`, `title`, and `nodeLabel` are ignored** — adding an `aria-label` fixes the a11y accessible-name but does **not** satisfy this SEO audit.
+
+To keep a design's non-descriptive label (e.g. a "LEARN MORE" button) *and* pass, append a visually-hidden descriptive suffix **inside** the anchor so it becomes part of innerText:
+
+```php
+<a class="btn" href="<?php echo esc_url( $url ); ?>">
+    <?php echo esc_html( $label ); // e.g. "LEARN MORE" — stays visible ?>
+    <?php if ( $context ) : ?><span class="screen-reader-text"><?php
+        echo esc_html( 'about ' . $context ); // e.g. "about Home Search"
+    ?></span><?php endif; ?>
+</a>
+```
+
+Now `link.text` = "LEARN MORE about Home Search" → not a blocklist match → audit passes; the button still visually reads "LEARN MORE".
+
+- **Critical:** the hidden span must use the `.screen-reader-text` **clip** pattern (`position:absolute; clip: rect(...); width:1px`) — NOT `display:none` or `visibility:hidden`, which are excluded from innerText and would fail again. (A `.screen-reader-text` rule is required in the theme CSS; see a11y standards.)
+- The same non-descriptive label often repeats across a reusable button component — fix the component/template part once, then re-check *every* page that uses it (Lighthouse audits per-URL; a homepage pass doesn't clear inner pages).
+- `identical-links-same-purpose` (a11y, weight 0) can also flag two same-text links (e.g. two "VIEW ALL") pointing to different destinations — the same hidden-suffix technique resolves it.
+
+### Meta description: let the SEO plugin own it — don't emit a theme fallback
+
+If Rank Math (or Yoast) is active and configured, do **not** also `echo` a hardcoded `<meta name="description">` from the theme `wp_head`. Two tags = a duplicate-description warning, and the plugin's dynamic/templated value is the one you want. A common failure mode: a theme adds a front-page meta-description fallback "to be safe" while the SEO plugin's setup wizard was incomplete → once the wizard is finished, the tag is duplicated. Remove the theme fallback; verify only one `<meta name="description">` renders (`curl -s <url> | grep -c 'name="description"'` → `1`).

--- a/skills/wp-audit-standards/SKILL.md
+++ b/skills/wp-audit-standards/SKILL.md
@@ -127,7 +127,67 @@ Lighthouse-style browser audits. Requires the web-quality-skills package for bro
 
 ---
 
-## Auto-Fix Classification
+## Performance — Hard-won Lessons (Tier 3 / Lighthouse)
+
+Interpretation traps and fixes that actually move production bytes. Consult before filing or fixing a `PERF-xxx` finding from a Lighthouse run.
+
+### Read *observed* metrics before chasing a bad *simulated* score
+
+Lighthouse's default (`throttlingMethod: "simulate"`) reports **Lantern-simulated** LCP/FCP/TTI on a modeled slow-4G + 4× CPU. On a **dev server** this is dominated by local TTFB + the throttle model and can read 6–7 s while the page is actually instant. Before treating a high LCP as real, open the full JSON and compare:
+
+- `audits.metrics.details.items[0].largestContentfulPaint` (simulated) **vs** `...observedLargestContentfulPaint` (real paint).
+- If observed is ~200–900 ms and simulated is multi-second, the number is a **simulation/dev-server artifact** — the score barely moves regardless of theme changes, and production (with page cache + real CDN/TTFB) differs. Say so in the finding instead of burning effort chasing it. **Real byte reductions (WebP, right-sizing) still help production** and still shrink the *LCP resource*, so do those — just set score expectations.
+- `image-delivery-insight`, `render-blocking-insight`, `lcp-discovery-insight` etc. are **weight-0** in the Performance score (informative). Only the 5 metric audits (FCP/LCP/TBT/CLS/SI) carry weight. Fixing a weight-0 insight is a production win, not a score win — label it accordingly.
+
+### WebP: `image_editor_output_format` only covers NEW, attachment-pipeline images
+
+`add_filter('image_editor_output_format', ...)` converts uploads to WebP **only on new uploads**, and **only images that flow through WP's attachment functions** (`wp_get_attachment_image`, `the_post_thumbnail`). Themes that print **raw SCF/ACF field URLs** (`echo $field['url']`) or CSS `background-image: url(<field>)` bypass it entirely, so existing hero/about/neighborhood/banner images stay JPEG/PNG.
+
+To serve WebP for **existing + SCF-driven** images without touching every template:
+
+1. Pre-generate `.webp` siblings for existing uploads (one-time): `find uploads -iname '*.jpg' -o -iname '*.png'` → `magick "$f" -quality 82 "${f%.*}.webp"` (hero/LCP images can go lower, ~q68, since they sit behind scrims or are video-replaced).
+2. Add a front-end output-buffer that rewrites finished HTML — covers `src`, `srcset`, and inline `background-image` in one pass:
+
+```php
+add_action( 'template_redirect', function () {
+    if ( is_admin() || is_feed() || is_robots() ) return;
+    $u = wp_get_upload_dir(); $base = $u['baseurl']; $dir = $u['basedir'];
+    ob_start( function ( $html ) use ( $base, $dir ) {
+        $pat = '#' . preg_quote( $base, '#' ) . '/[^"\'\)\s]+?\.(?:jpe?g|png)#i';
+        return preg_replace_callback( $pat, function ( $m ) use ( $base, $dir ) {
+            $webp = preg_replace( '/\.(?:jpe?g|png)$/i', '.webp', $m[0] );
+            return file_exists( $dir . substr( $webp, strlen( $base ) ) ) ? $webp : $m[0];
+        }, $html );
+    } );
+} );
+```
+
+`template_redirect` is front-end-only, and with a page cache (WP Super Cache) the buffer runs once per cache build. WebP is universally supported by target browsers — matching the theme's existing unconditional `image_editor_output_format` policy — so no `Accept`-header branching is needed.
+
+### Right-size — never print `$field['url']` for a fixed slot
+
+Lighthouse "responsive-size" waste = serving a 2200px original in a 400px slot. Raw SCF field URLs (`$image['url']`) always emit the **full original**. Use the attachment ID so the browser gets a `srcset`:
+
+```php
+echo wp_get_attachment_image( (int) $image['id'], 'large', false, array(
+    'class' => 'about__bg', 'alt' => $heading, 'loading' => 'lazy',
+    'sizes' => '(max-width: 899px) 100vw, 136vw', // match the real CSS display width
+) );
+```
+
+Pick `sizes` from the element's actual rendered width (full-bleed → `100vw`; a 136%-wide bg → `136vw`; a 136px logo → `136px`). This composes with the WebP buffer above (the srcset `.jpg` URLs are rewritten to `.webp`).
+
+### Hero LCP pattern (poster-first, video deferred)
+
+Make the LCP element a **small poster image**, not the video: `<img fetchpriority="high" width/height>` + a `<link rel="preload" as="image">` for it in `wp_head`; lazy-load the background `<video>` via JS on **desktop only** (`min-width:1024px`), after the poster paints (`requestIdleCallback`), and **never** on mobile / `navigator.connection.saveData`. Preload the poster's WebP so the preload and the rendered `src` match (else the preload is wasted).
+
+### Render-blocking CSS
+
+Dequeue the near-empty theme `style.css` on the front end (it usually carries only the WP header comment; runtime styles live in the compiled bundle). Async-load below-the-fold plugin CSS (e.g. Contact Form 7) via `style_loader_tag` → `media='print' onload="this.media='all'"`.
+
+### AIOS × Lighthouse gotcha (Tier 2 ↔ Tier 3 interaction)
+
+If the security agent sets AIOS `aiowps_disallow_unauthorized_rest_requests = 1`, it returns **403** on CF7's REST endpoints (`/wp-json/contact-form-7/v1/...`). Lighthouse then **hangs up to 45 s** on those pending requests and logs console errors → Best-Practices drops (often 100 → 96) and metrics inflate. If a CF7 form is present, leave that AIOS setting off (or whitelist the CF7 REST namespace). Symptom in the JSON: `errors-in-console` / pending `Fetch` requests to `contact-form-7` with `statusCode: 403`.
 
 ### Auto-fixable
 

--- a/skills/wp-bilingual/SKILL.md
+++ b/skills/wp-bilingual/SKILL.md
@@ -465,7 +465,7 @@ The pattern is: `<location>-<lang>` (e.g., `primary-en`, `primary-es`, `mobile-e
 
 ## ACF Field Creation Rules
 
-When defining fields in `inc/scf-fields.php` for a bilingual site:
+When defining fields in `fields/*.php` for a bilingual site (see wp-theme-standards for the field loader / Local JSON model — `fields/*.php` is a one-time bootstrap seed, `acf-json/*.json` is the dashboard-editable source of truth):
 
 ### Field Organization
 
@@ -616,12 +616,15 @@ In `header.php`, set the document language dynamically.
 
 ## File Structure
 
-The i18n system lives in a single file included early in `functions.php`.
+The i18n system lives in a single file included early in `functions.php`, before the field loader's `acf/init` hook runs.
 
 ```php
-// functions.php — i18n must load before SCF fields
+// functions.php — i18n must load before the fields/*.php bootstrap
 require get_template_directory() . '/inc/i18n.php';
-require get_template_directory() . '/inc/scf-fields.php';
+
+// Field groups loaded via the acf/init bootstrap loader (fields/*.php seeds
+// acf-json/, which becomes the dashboard-editable source of truth) —
+// see wp-theme-standards SKILL.md for the full loader.
 ```
 
 The `inc/i18n.php` file contains:

--- a/skills/wp-theme-standards/SKILL.md
+++ b/skills/wp-theme-standards/SKILL.md
@@ -56,6 +56,7 @@ theme-name/
 ├── inc/
 │   ├── theme-setup.php         # Theme supports, nav menus, content width
 │   ├── i18n.php                # Internationalization helpers (if bilingual)
+│   ├── performance.php         # WebP delivery + prefix_image() right-size helper
 │   └── scf-fields.php          # SCF/ACF custom field definitions
 ├── template-parts/
 │   ├── section-hero.php        # Reusable section templates
@@ -360,10 +361,28 @@ function prefix_preload_lcp_image() {
     if (is_front_page()) {
         $hero_image = prefix_get_field('hero_image');
         $hero_image_url = $hero_image ? $hero_image['url'] : prefix_asset('images/hero-image.png');
-        echo '<link rel="preload" as="image" href="' . esc_url($hero_image_url) . '">' . "\n";
+        echo '<link rel="preload" as="image" href="' . esc_url($hero_image_url) . '" fetchpriority="high">' . "\n";
     }
 }
 add_action('wp_head', 'prefix_preload_lcp_image', 2);
+```
+
+The preloaded LCP `<img>` itself must carry `fetchpriority="high"` + `width`/`height`. If the hero is a background video, keep the poster `<img>` as the LCP element and lazy-load the `<video>` via JS on desktop only (never mobile / `navigator.connection.saveData`).
+
+### Image Delivery — WebP + right-sizing (`inc/performance.php`)
+
+Ship `inc/performance.php` (in the starter) in every theme. It handles the image-delivery waste Lighthouse flags, which `image_editor_output_format` alone does **not** cover:
+
+1. `image_editor_output_format` → WebP for new attachment sub-sizes.
+2. `wp_generate_attachment_metadata` → also writes a WebP sibling for the full-size original (so raw-URL / CSS-background usage benefits).
+3. A `template_redirect` output-buffer that rewrites any `uploads/*.jpg|png` with a `.webp` sibling → `.webp` in the finished HTML (covers `src`, `srcset`, and inline `background-image` — including SCF field URLs that bypass WP's attachment pipeline). Runs once per page-cache build.
+4. `prefix_image($field, $size, $attr)` — templates use this instead of `echo $field['url']` so images get a `srcset` sized to the slot. **Always pass `sizes`** matching the real display width (full-bleed `100vw`, split `(max-width: 899px) 100vw, 50vw`, fixed logo `136px`). Serving a 2200px original in a 400px slot is the top oversized-image finding.
+
+For a theme seeded from an existing demo (images already uploaded), batch-generate the `.webp` siblings once so (3) picks them up:
+
+```bash
+find wp-content/uploads -type f \( -iname '*.jpg' -o -iname '*.png' \) \
+  -exec sh -c 'f="$1"; w="${f%.*}.webp"; [ -f "$w" ] || magick "$f" -quality 82 "$w"' _ {} \;
 ```
 
 ### Disable WordPress Emojis

--- a/skills/wp-theme-standards/SKILL.md
+++ b/skills/wp-theme-standards/SKILL.md
@@ -56,8 +56,14 @@ theme-name/
 ├── inc/
 │   ├── theme-setup.php         # Theme supports, nav menus, content width
 │   ├── i18n.php                # Internationalization helpers (if bilingual)
-│   ├── performance.php         # WebP delivery + prefix_image() right-size helper
-│   └── scf-fields.php          # SCF/ACF custom field definitions
+│   └── performance.php         # WebP delivery + prefix_image() right-size helper
+├── fields/                     # SCF/ACF field definitions — one file per group
+│   ├── hero.php                #   BARE acf_add_local_field_group() calls (seed only)
+│   ├── settings.php
+│   └── ...
+├── acf-json/                   # SCF/ACF Local JSON — the field SOURCE OF TRUTH
+│   ├── group_hero.json         #   auto-written from fields/*.php on first load,
+│   └── ...                     #   dashboard-editable, edits sync back here
 ├── template-parts/
 │   ├── section-hero.php        # Reusable section templates
 │   ├── section-services.php
@@ -70,6 +76,22 @@ theme-name/
 ├── style.css                   # Theme declaration (headers only)
 └── screenshot.png              # Theme preview image
 ```
+
+### SCF/ACF field model — Local JSON is the source of truth
+
+Field groups are **not** left as pure PHP `acf_add_local_field_group()` registrations:
+a PHP-local group has no post (`ID=0`), never appears in **Custom Fields → Field
+Groups**, and can't be edited or extended by the client. Instead the `acf/init`
+loader in `functions.php` treats `fields/*.php` as a **one-time bootstrap** — it
+registers each group once, writes it to `acf-json/<key>.json`, then loads only the
+Local JSON thereafter. ACF/SCF auto-loads `acf-json/`, so groups are visible,
+editable, and two-way synced (dashboard edits — including manually added fields —
+are written back to the JSON files and stay in version control).
+
+To **redefine** an existing group in code, edit its `fields/*.php` and delete the
+matching `acf-json/<key>.json` (plus `acf_delete_field_group('<key>')` if imported
+to the DB) so it re-bootstraps. Never point `save_json`/`load_json` elsewhere —
+ACF already defaults to the theme's `acf-json/`.
 
 ---
 

--- a/starter-theme/__cinematic__/functions.php
+++ b/starter-theme/__cinematic__/functions.php
@@ -37,9 +37,37 @@ require_once __STARTER___THEME_DIR . '/inc/cinematic-loader.php';
 require_once __STARTER___THEME_DIR . '/inc/scenes-renderer.php';
 require_once __STARTER___THEME_DIR . '/inc/performance.php';
 
-// ACF auto-loader (drops in fields/*.php).
-if (function_exists('acf_add_local_field_group')) {
-    foreach (glob(__STARTER___THEME_DIR . '/fields/*.php') as $f) {
+// Field groups use ACF/SCF Local JSON (acf-json/) as the single source of truth
+// so they stay editable in the dashboard AND versioned in code. fields/*.php are
+// a one-time bootstrap: registered on first load with no JSON yet, then persisted
+// to acf-json/. Once JSON exists it is the only source loaded (re-running the PHP
+// would re-register the same keys as read-only PHP-local groups).
+add_action('acf/init', function () {
+    $json_dir   = __STARTER___THEME_DIR . '/acf-json';
+    $fields_dir = __STARTER___THEME_DIR . '/fields';
+    if (!is_dir($fields_dir)) { return; }
+    if (!is_dir($json_dir)) { wp_mkdir_p($json_dir); }
+
+    // Bootstrap each group from PHP only if it isn't already Local JSON. A group
+    // that has a acf-json/<key>.json is the source of truth (dashboard edits sync
+    // there); re-running its PHP would re-register it read-only and shadow edits.
+    foreach (glob($fields_dir . '/*.php') as $f) {
+        $src = file_get_contents($f);
+        if (preg_match_all("/'key'\\s*=>\\s*'(group_[A-Za-z0-9_]+)'/", $src, $m)) {
+            $pending = false;
+            foreach ($m[1] as $key) {
+                if (!file_exists("$json_dir/$key.json")) { $pending = true; break; }
+            }
+            if (!$pending) { continue; }
+        }
         require_once $f;
     }
-}
+
+    // Persist any freshly-registered PHP-local group to Local JSON (editable).
+    foreach (acf_get_field_groups() as $g) {
+        if (($g['local'] ?? '') !== 'php') { continue; }
+        if (file_exists("$json_dir/{$g['key']}.json")) { continue; }
+        $g['fields'] = acf_get_fields($g);
+        acf_write_json_field_group(acf_prepare_field_group_for_export($g));
+    }
+});

--- a/starter-theme/__tailwind__/assets/css/src/tailwindcss/utilities/wordpress.css
+++ b/starter-theme/__tailwind__/assets/css/src/tailwindcss/utilities/wordpress.css
@@ -10,3 +10,35 @@
 .wp-caption {
   @apply max-w-full mx-auto;
 }
+
+/* Visually-hidden text for screen readers (WP core template-tags rely on this,
+   and it's the correct way to add descriptive text to generic-labelled links —
+   e.g. a "LEARN MORE" button — so Lighthouse's link-text audit sees descriptive
+   innerText. Uses clip (NOT display:none) so the text stays in innerText/the
+   accessibility tree). */
+.screen-reader-text {
+  border: 0;
+  clip: rect(1px, 1px, 1px, 1px);
+  clip-path: inset(50%);
+  height: 1px;
+  width: 1px;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  position: absolute !important;
+  word-wrap: normal !important;
+}
+
+.screen-reader-text:focus {
+  background-color: #f1f1f1;
+  clip: auto !important;
+  clip-path: none;
+  color: #21759b;
+  display: block;
+  height: auto;
+  left: 5px;
+  top: 5px;
+  padding: 15px 23px 14px;
+  width: auto;
+  z-index: 100000;
+}

--- a/starter-theme/__tailwind__/functions.php
+++ b/starter-theme/__tailwind__/functions.php
@@ -20,14 +20,42 @@ require_once __STARTER___DIR . '/inc/template-functions.php';
 require_once __STARTER___DIR . '/inc/performance.php';
 
 /**
- * Auto-load ACF/SCF field definitions from fields/ directory.
+ * Field groups use ACF/SCF Local JSON (acf-json/) as the single source of truth
+ * so they stay editable in the dashboard AND versioned in code — dashboard edits
+ * (including manually added fields) sync back to the JSON files.
+ *
+ * fields/*.php are a one-time bootstrap: on the first load with no JSON yet, they
+ * register the groups and get persisted to acf-json/. Once JSON exists it is the
+ * only source loaded — re-running the PHP would re-register the same keys as
+ * read-only PHP-local groups and shadow the editable JSON copies.
  */
 add_action( 'acf/init', function() {
+    $json_dir   = __STARTER___DIR . '/acf-json';
     $fields_dir = __STARTER___DIR . '/fields';
-    if ( is_dir( $fields_dir ) ) {
-        foreach ( glob( $fields_dir . '/*.php' ) as $file ) {
-            require_once $file;
+    if ( ! is_dir( $fields_dir ) ) { return; }
+    if ( ! is_dir( $json_dir ) ) { wp_mkdir_p( $json_dir ); }
+
+    // Bootstrap each group from PHP only if it isn't already Local JSON. A group
+    // that has a acf-json/<key>.json is the source of truth (dashboard edits sync
+    // there); re-running its PHP would re-register it read-only and shadow edits.
+    foreach ( glob( $fields_dir . '/*.php' ) as $file ) {
+        $src = file_get_contents( $file );
+        if ( preg_match_all( "/'key'\\s*=>\\s*'(group_[A-Za-z0-9_]+)'/", $src, $m ) ) {
+            $pending = false;
+            foreach ( $m[1] as $key ) {
+                if ( ! file_exists( "$json_dir/$key.json" ) ) { $pending = true; break; }
+            }
+            if ( ! $pending ) { continue; } // every group in this file already has JSON
         }
+        require_once $file;
+    }
+
+    // Persist any freshly-registered PHP-local group to Local JSON (editable).
+    foreach ( acf_get_field_groups() as $g ) {
+        if ( ( $g['local'] ?? '' ) !== 'php' ) { continue; }
+        if ( file_exists( "$json_dir/{$g['key']}.json" ) ) { continue; }
+        $g['fields'] = acf_get_fields( $g );
+        acf_write_json_field_group( acf_prepare_field_group_for_export( $g ) );
     }
 });
 

--- a/starter-theme/__tailwind__/functions.php
+++ b/starter-theme/__tailwind__/functions.php
@@ -17,6 +17,7 @@ require_once __STARTER___DIR . '/inc/cf7-helpers.php';
 require_once __STARTER___DIR . '/inc/nav-walker.php';
 require_once __STARTER___DIR . '/inc/template-tags.php';
 require_once __STARTER___DIR . '/inc/template-functions.php';
+require_once __STARTER___DIR . '/inc/performance.php';
 
 /**
  * Auto-load ACF/SCF field definitions from fields/ directory.

--- a/starter-theme/__tailwind__/inc/performance.php
+++ b/starter-theme/__tailwind__/inc/performance.php
@@ -1,0 +1,112 @@
+<?php
+/**
+ * Performance: image delivery (WebP + right-sizing helpers).
+ *
+ * @package __starter__
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * 1) New uploads: generate WebP for the resized sub-sizes.
+ *
+ * Note this only affects images that later flow through WP's attachment
+ * functions (wp_get_attachment_image, the_post_thumbnail). Templates that print
+ * a raw SCF/ACF field URL (echo $field['url']) or a CSS background-image bypass
+ * it — those are handled by the output-buffer rewrite in (3).
+ */
+add_filter( 'image_editor_output_format', function ( $formats ) {
+	$formats['image/jpeg'] = 'image/webp';
+	$formats['image/png']  = 'image/webp';
+	return $formats;
+} );
+
+/**
+ * 2) On upload, also write a WebP sibling next to the FULL-SIZE original, so
+ * raw-URL and CSS-background usage (which reference the original) can be served
+ * as WebP by (3). WP keeps the original in its uploaded format; this fills that
+ * gap. For a theme seeded from an existing demo, batch-generate the siblings
+ * once (any image with a `.webp` next to it is picked up automatically):
+ *
+ *   find wp-content/uploads -type f \( -iname '*.jpg' -o -iname '*.png' \) \
+ *     -exec sh -c 'f="$1"; w="${f%.*}.webp"; [ -f "$w" ] || magick "$f" -quality 82 "$w"' _ {} \;
+ */
+add_filter( 'wp_generate_attachment_metadata', function ( $metadata, $attachment_id ) {
+	$file = get_attached_file( $attachment_id );
+	if ( ! $file || ! preg_match( '/\.(jpe?g|png)$/i', $file ) ) {
+		return $metadata;
+	}
+	$webp = preg_replace( '/\.(?:jpe?g|png)$/i', '.webp', $file );
+	if ( file_exists( $webp ) ) {
+		return $metadata;
+	}
+	$editor = wp_get_image_editor( $file );
+	if ( ! is_wp_error( $editor ) ) {
+		$editor->save( $webp, 'image/webp' );
+	}
+	return $metadata;
+}, 10, 2 );
+
+/**
+ * 3) Serve WebP for EXISTING + raw-URL + CSS-background images by rewriting the
+ * finished HTML: any wp-content/uploads *.jpg/.png with a `.webp` sibling on
+ * disk is swapped to `.webp` — covering <img src>, srcset, and inline
+ * background-image in one pass. `template_redirect` is front-end only, and with
+ * a page cache the buffer runs once per cache build. WebP is universally
+ * supported by target browsers (matching the unconditional policy in (1)), so
+ * no Accept-header branching is needed.
+ */
+add_action( 'template_redirect', function () {
+	if ( is_admin() || is_feed() || is_robots() ) {
+		return;
+	}
+	$uploads  = wp_get_upload_dir();
+	$base_url = $uploads['baseurl'];
+	$base_dir = $uploads['basedir'];
+
+	ob_start( function ( $html ) use ( $base_url, $base_dir ) {
+		if ( '' === $html ) {
+			return $html;
+		}
+		$pattern = '#' . preg_quote( $base_url, '#' ) . '/[^"\'\)\s]+?\.(?:jpe?g|png)#i';
+		return preg_replace_callback( $pattern, function ( $m ) use ( $base_url, $base_dir ) {
+			$webp = preg_replace( '/\.(?:jpe?g|png)$/i', '.webp', $m[0] );
+			$path = $base_dir . substr( $webp, strlen( $base_url ) );
+			return file_exists( $path ) ? $webp : $m[0];
+		}, $html );
+	} );
+} );
+
+/**
+ * Right-sized <img> from an SCF/ACF image field.
+ *
+ * Prefer this over `echo $field['url']` (which always emits the full-size
+ * original — the #1 cause of Lighthouse "responsive-size" / oversized-image
+ * waste). Passing the attachment ID lets WP emit a srcset the browser can pick
+ * from; the WebP rewrite in (3) then swaps those URLs to `.webp`.
+ *
+ * @param mixed  $field SCF/ACF image field (array with 'id'/'url', or an ID/URL).
+ * @param string $size  Registered image size for the base src (default 'large').
+ * @param array  $attr  Extra attributes. ALWAYS set 'sizes' to the element's
+ *                      real rendered width, e.g. '(max-width: 899px) 100vw, 50vw',
+ *                      a full-bleed hero '100vw', or a fixed logo '136px'.
+ * @return string <img> HTML (empty string if the field is empty).
+ */
+function __starter___image( $field, $size = 'large', $attr = array() ) {
+	$id = is_array( $field ) ? (int) ( $field['id'] ?? 0 ) : ( is_numeric( $field ) ? (int) $field : 0 );
+	if ( $id ) {
+		return wp_get_attachment_image( $id, $size, false, $attr );
+	}
+	// Fallback: a bare URL (e.g. a theme asset) with no attachment behind it.
+	$url = is_array( $field ) ? ( $field['url'] ?? '' ) : (string) $field;
+	if ( ! $url ) {
+		return '';
+	}
+	$out = '<img src="' . esc_url( $url ) . '"';
+	foreach ( $attr as $k => $v ) {
+		$out .= ' ' . esc_attr( $k ) . '="' . esc_attr( $v ) . '"';
+	}
+	return $out . ' />';
+}


### PR DESCRIPTION
## Summary
- PHP-local `acf_add_local_field_group()` groups have no DB post (`ID=0`) and never appear under **Custom Fields → Field Groups** in the dashboard, so clients can't view or edit them (root cause found while debugging the nancy-kennedy project).
- The `acf/init` loader in both starter themes now treats `fields/*.php` as a **one-time bootstrap per group**: a group's PHP only runs while its `acf-json/<key>.json` doesn't exist yet; once persisted, ACF/SCF's built-in Local JSON auto-load takes over and dashboard edits sync back to the JSON file.
- Updated `wp-acf`, `wp-cinematic`, `wp-finalize`, `wp-settings`, `wp-bilingual`, and `wp-theme-standards` so every agent/skill/command that touches field groups documents the Local JSON model and the invalidation step needed when a group's PHP definition is edited after JSON already exists.

## Test plan
- [x] `php -l` on both starter `functions.php` files — no syntax errors
- [x] Applied the same loader to an existing production theme (nancy-kennedy) and verified via WP-CLI: 25/25 field groups became DB-backed and dashboard-editable (0 stuck PHP-local), fields still resolve correctly (`acf_get_fields`)
- [x] Verified per-group (not per-theme) invalidation, so incrementally adding a new section's field file to a theme that already has JSON for other groups still bootstraps correctly
- [ ] Manual: run `/wp-init` → `/wp-section` on a fresh scaffold and confirm the new group appears immediately under Custom Fields → Field Groups

🤖 Generated with [Claude Code](https://claude.com/claude-code)